### PR TITLE
Added wp-config.txt backup file check

### DIFF
--- a/lib/wpscan/modules/wp_config_backup.rb
+++ b/lib/wpscan/modules/wp_config_backup.rb
@@ -50,7 +50,7 @@ module WpConfigBackup
     %w{
       wp-config.php~ #wp-config.php# wp-config.php.save wp-config.php.swp wp-config.php.swo wp-config.php_bak
       wp-config.bak wp-config.php.bak wp-config.save wp-config.old wp-config.php.old wp-config.php.orig
-      wp-config.orig wp-config.php.original wp-config.original
+      wp-config.orig wp-config.php.original wp-config.original wp-config.txt
     } # thanks to Feross.org for these
   end
 


### PR DESCRIPTION
wp-config.txt is a common backup file for the config that is not currently being checked.
