### PR TITLE
Update lib/environment.rb

### DIFF
--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -31,7 +31,7 @@ begin
   require 'rbconfig'
   require 'pp'
   # Third party libs
-  gem 'typhoeus', '=0.4.2'
+  gem 'typhoeus', '>=0.4.2'
   require 'typhoeus'
   require 'json'
   require 'nokogiri'


### PR DESCRIPTION
wpscan fails on Typhoeus version > 0.4.2
