### PR TITLE
wrong usage of 'unless' for nil check

### DIFF
--- a/lib/wpscan/web_site.rb
+++ b/lib/wpscan/web_site.rb
@@ -53,7 +53,7 @@ class WebSite
 
       unless headers.nil?
         value = headers['X-Pingback']
-        unless value.nil? && value.empty?
+        if value && !value.empty?
           @xmlrpc_url = value
         end
       end


### PR DESCRIPTION
Sometimes this was causing a

```
undefined method `empty?' for nil:NilClass
```
