### PR TITLE
removed feed plugin vulnerability issue

### DIFF
--- a/data/plugin_vulns.xml
+++ b/data/plugin_vulns.xml
@@ -4954,13 +4954,6 @@
     </vulnerability>
   </plugin>
 
-  <plugin name="feed">
-    <vulnerability>
-      <title>Feed news_dt.php nid Parameter SQL Injection</title>
-      <reference>http://osvdb.org/94804</reference>
-      <type>SQLI</type>
-    </vulnerability>
-  </plugin>
 
   <plugin name="buddypress-extended-friendship-request">
     <vulnerability>


### PR DESCRIPTION
Removed Feed plugin vulnerability as this is not provable as well as there is no publically listed plugin nor any traces or a private plugin of such name. this corresponds to issue no #244
