### PR TITLE
Update plugin_vulns.xml: SQL injection fixed in events-calendar version ...

### DIFF
--- a/data/plugin_vulns.xml
+++ b/data/plugin_vulns.xml
@@ -2289,6 +2289,7 @@
       <title>Events SQL Injection Vulnerability</title>
       <reference>http://www.exploit-db.com/exploits/10929/</reference>
       <type>SQLI</type>
+      <fixed_in>6.7.10</fixed_in>
     </vulnerability>
   </plugin>
 


### PR DESCRIPTION
SQL Injection at events-calendar has been fixed at version 6.7.10. 
Reference: readme.txt

And I have tested it also with events-calendar 6.7.13 and no more SQL injection vulnerability. 
