### PR TITLE
Don't skip passwords that start with a hash. 

### DIFF
--- a/lib/common/models/wp_user/brute_forcable.rb
+++ b/lib/common/models/wp_user/brute_forcable.rb
@@ -141,8 +141,6 @@ class WpUser < WpItem
         opt      += ':UTF-8' if charset != 'UTF-8'
 
         File.open(wordlist, opt).each do |line|
-          next if line[0,1] == '#'
-
           passwords << line.strip
         end
       elsif wordlist.is_a?(Array)


### PR DESCRIPTION
Don't skip passwords that start with a hash. I assume the intention was to skip comments, but this is fairly common (see RockYou list for example).

http://www.skullsecurity.org/wiki/index.php/Passwords
