### PR TITLE
/.bundle should be in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ log.txt
 .yardoc
 debug.log
 wordlist.txt
+/.bundle


### PR DESCRIPTION
If user run `bundle install --without test development`, it generated .bundle/config on the root directory
