### PR TITLE
minor doc changes for Debian Wheezy

### DIFF
--- a/README
+++ b/README
@@ -39,7 +39,7 @@ ryandewhurst at gmail
   Prerequisites:
 
    * Windows not supported
-   * Ruby >= 1.9.2 - Recommended: 1.9.3 
+   * Ruby >= 1.9.2 - Recommended: 1.9.3
    * Curl >= 7.21  - Recommended: latest - FYI the 7.29 has a segfault
    * RubyGems      - Recommended: latest
    * Git


### PR DESCRIPTION
Debian Wheezy has a 'bundle' package which replaces the need to gem install bundler.
