### PR TITLE
Existable.login_from_author_pattern(text) when text is nil

### DIFF
--- a/lib/common/models/wp_user/existable.rb
+++ b/lib/common/models/wp_user/existable.rb
@@ -37,6 +37,7 @@ class WpUser < WpItem
     #
     # @return [ String ] The login
     def self.login_from_author_pattern(text)
+      text = String.new if text.nil?
       text[%r{/author/([^/\b]+)/?}i, 1]
     end
 

--- a/spec/shared_examples/wp_user/existable.rb
+++ b/spec/shared_examples/wp_user/existable.rb
@@ -29,6 +29,14 @@ shared_examples 'WpUser::Existable' do
         @expected = nil
       end
     end
+
+    context 'when text is nil' do
+      it 'proceedes without exception' do
+        @text     = nil
+        @expected = nil
+      end
+    end
+
   end
 
   describe '::login_from_body' do


### PR DESCRIPTION
See Gist for Error: https://gist.github.com/superscott/44d428e1b0ab6d6b0759
Just added Nil check before proceeding, and added additional test for when Text is nil.

OSX: 10.9.4
Ruby: ruby 2.1.2p95 (2014-05-08 revision 45877) [x86_64-darwin13.0]
RVM: Yes.
