### PR TITLE
Update README - fix typo in Ubuntu 14.04 instructions

### DIFF
--- a/README
+++ b/README
@@ -53,7 +53,7 @@ wpscanteam at gmail.com
 
     From Ubuntu 14.04:
 
-        sudo apt-get install libcurl4-gnutls-dev libxml2 libxml2-dev libxslt1-dev ruby-dev build-essentials
+        sudo apt-get install libcurl4-gnutls-dev libxml2 libxml2-dev libxslt1-dev ruby-dev build-essential
 
     git clone https://github.com/wpscanteam/wpscan.git
     cd wpscan


### PR DESCRIPTION
"sudo apt-get install" line had "build-essentials" instead of "build-essential"
