### PR TITLE
Fix UTF-8 encode on security db file download

### DIFF
--- a/lib/common/db_updater.rb
+++ b/lib/common/db_updater.rb
@@ -73,7 +73,7 @@ class DbUpdater
 
     res = Browser.get(file_url, request_params)
     fail "Error while downloading #{file_url}" unless res.code == 200
-    File.write(file_path, res.body)
+    File.open(file_path, 'wb') { |f| f.write(res.body) }
 
     local_file_checksum(filename)
   end


### PR DESCRIPTION
Using your db updater on another process like Sidekiq throw this following error on file download: 

```
Encoding::UndefinedConversionError: "\xE6" from ASCII-8BIT to UTF-8
```

For file downloading, it's better to open the file on binary mode `b`.

This PR fixes this issue.

Thanks.
