### PR TITLE
Experimental Windows Support

### DIFF
--- a/README
+++ b/README
@@ -98,7 +98,7 @@ Running WPScan against websites without prior mutual consent may be illegal in y
    * RubyGems      - Recommended: latest
    * Git
 
-   Windows is not supported.
+   Windows is not supported, but may work on your system.
 
    If installed from Github update the code base with git pull. The databases are updated with wpscan.rb --update.
 
@@ -166,6 +166,27 @@ Running WPScan against websites without prior mutual consent may be illegal in y
     git clone https://github.com/wpscanteam/wpscan.git
     cd wpscan
     bundle install --without test
+    
+  -> Experimental: Installing on Windows
+    Does not work using cmd.exe; see known issues
+    
+    Tested on Windows 8.1 64-bit using Powershell as posh~git (comes with Github for Windows)
+    - 2.0.0p247 x64: Exit code 0 (works)
+    - 2.1.3p242 x64: Exit code 0 (works)
+    - 2.1.5p273 x64: Exit code 0 (works)
+    - jruby 1.7.18 (1.9.3p551) on 1.7.0_25-b17 +jit x64: Exit code 0 (works) (but pretty print is ugly)
+
+    Make sure you have DevKit installed (64bit version for 64bit ruby and 32bit version for 32bit ruby)
+    Make sure your ruby is at least 2.1.5
+
+    git clone https://github.com/wpscanteam/wpscan.git
+    cd wpscan
+    gem install bundler
+    bundle install --without test
+    
+    For any gem that fails (so that it will invoke the devkit)
+    
+    gem install FAILING_GEM -v VERSION
 
 ==KNOWN ISSUES==
 
@@ -202,6 +223,8 @@ Running WPScan against websites without prior mutual consent may be illegal in y
 
       See https://github.com/wpscanteam/wpscan/issues/148
 
+    - No such file or directory - ps -o rss= -p NUMBER       
+      On windows you can't run using cmd.exe (not even in Administrator mode). You will need a shell that has hooks to support UNIX calls such as PowerShell
 
 ==WPSCAN ARGUMENTS==
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Prerequisites:
 - RubyGems      - Recommended: latest
 - Git
 
-Windows is not supported.
+Windows is not supported, but may work on your system.
 If installed from Github update the code base with ```git pull```. The databases are updated with ```wpscan.rb --update```.
 
 ####Installing on Ubuntu:
@@ -162,6 +162,25 @@ Apple Xcode, Command Line Tools and the libffi are needed (to be able to install
     git clone https://github.com/wpscanteam/wpscan.git
     cd wpscan
     bundle install --without test
+    
+####Experimental: Installing on Windows
+Does not work using cmd.exe; see known issues
+Tested on Windows 8.1 64-bit using Powershell as posh~git (comes with Github for Windows)
+- `2.0.0p247 x64`: Exit code 0 **works**
+- `2.1.3p242 x64`: Exit code 0 **works**
+- `2.1.5p273 x64`: Exit code 0 **works**
+- `jruby 1.7.18 (1.9.3p551) on 1.7.0_25-b17 +jit x64`: Exit code 0 **works** (but pretty print is ugly)
+
+Make sure you have DevKit installed (64bit version for 64bit ruby and 32bit version for 32bit ruby)
+Make sure your ruby is at least 2.1.5
+
+    git clone https://github.com/wpscanteam/wpscan.git
+    cd wpscan
+    gem install bundler
+    bundle install --without test
+    
+For any gem that fails (so that it will invoke the devkit)
+    gem install FAILING_GEM -v VERSION
 
 #### KNOWN ISSUES
 
@@ -205,6 +224,10 @@ Apple Xcode, Command Line Tools and the libffi are needed (to be able to install
       And select your ruby version
 
       See [https://github.com/wpscanteam/wpscan/issues/148](https://github.com/wpscanteam/wpscan/issues/148)
+      
+   - No such file or directory - ps -o rss= -p NUMBER
+        
+        On windows you can't run using cmd.exe (not even in Administrator mode). You will need a shell that has hooks to support UNIX calls such as PowerShell
 
 #### WPSCAN ARGUMENTS
 

--- a/lib/common/common_helper.rb
+++ b/lib/common/common_helper.rb
@@ -199,8 +199,19 @@ def remove_base64_images_from_html(html)
   html.gsub(/["']\s*#{imageregex}#{base64regex}\s*["']/, '""')
 end
 
+class WindowsMemoryStub < BasicObject
+    def bytes_to_human
+        'unknown'
+    end
+    
+    def -( _ )
+        self
+    end
+end
+
 # @return [ Integer ] The memory of the current process in Bytes
 def get_memory_usage
+  return WindowsMemoryStub.new if Gem.win_platform?
   `ps -o rss= -p #{Process.pid}`.to_i * 1024 # ps returns the value in KB
 end
 


### PR DESCRIPTION
Under certain conditions wpscan works find under Windows. Amended README's with instructions and a stub for one of the helper functions.

- Windows 8.1 x64
- ruby 2.0.0 x64 + Devkit / jruby 1.9.3
- PowerShell

I bet it'll work under msysgit as well.