### PR TITLE
Available take username for wordpress 3.0 or lower.

### DIFF
--- a/lib/common/models/wp_user/existable.rb
+++ b/lib/common/models/wp_user/existable.rb
@@ -51,7 +51,7 @@ class WpUser < WpItem
 
       unless login
         # No Permalinks
-        login = body[%r{<body class="archive author author-([^\s]+) author-(\d+)}i, 1]
+        login = body[%r{<body class="archive author author-([^\s]+)[ "]}i, 1]
       end
 
       login


### PR DESCRIPTION
if username is "User"
wordpress3.0 or lower:
class="archive author author-User">
wordpress3.1 or higher:
class="archive author author-User author-1">

and,if user logged in,
class="archive author author-User author-1 logged-in">

we dont need author-number,logged-in status.so reversion regular expression.