### PR TITLE
Fix for malformed location: headers in redirects.

### DIFF
--- a/lib/wpscan/web_site.rb
+++ b/lib/wpscan/web_site.rb
@@ -55,6 +55,9 @@ class WebSite
     redirected_uri = URI.parse(add_trailing_slash(add_http_protocol(url)))
     if response.code == 301 || response.code == 302
       redirection = response.headers_hash['location']
+      if redirection[0] == '?'
+        redirection = "/#{redirection}"
+      end
       if redirection[0] == '/'
         redirection = "#{redirected_uri.scheme}://#{redirected_uri.host}#{redirection}"
       end


### PR DESCRIPTION
I ran into a website that had a bad location: 302 redirect at the landing page. It began with a '?' - and wpscan assumes that unless the redirect begins with a '/' (in which case the redirect is rewritten to a complete URI) that it is properly formed. 

This URI is apparently checked before you are asked if you want to follow the redirect, as I was attempting to scan a site that redirected to ?key=abcd, and wpscan crashed because it was attempting to parse http://?key=abcd before it asked if I wanted to follow the redirect.

By adding a check for a redirect that begins with '?', and if so, to prepend a '/' to it, solved the issue.