### PR TITLE
Virtualhost support

### DIFF
--- a/lib/common/browser.rb
+++ b/lib/common/browser.rb
@@ -24,7 +24,7 @@ class Browser
 
   attr_reader :hydra, :cache_dir
 
-  attr_accessor :referer, :cookie
+  attr_accessor :referer, :cookie, :virtualHost
 
   # @param [ Hash ] options
   #
@@ -135,7 +135,15 @@ class Browser
         @basic_auth
       )
     end
-
+    
+    if virtualHost
+      params = Browser.append_params_header_field(
+        params,
+        'Host',
+        virtualHost
+      )
+    end
+    
     params.merge!(referer: referer)
     params.merge!(timeout: @request_timeout) if @request_timeout
     params.merge!(connecttimeout: @connect_timeout) if @connect_timeout

--- a/lib/common/browser.rb
+++ b/lib/common/browser.rb
@@ -24,7 +24,7 @@ class Browser
 
   attr_reader :hydra, :cache_dir
 
-  attr_accessor :referer, :cookie, :virtualHost
+  attr_accessor :referer, :cookie, :vhost
 
   # @param [ Hash ] options
   #
@@ -136,11 +136,11 @@ class Browser
       )
     end
     
-    if virtualHost
+    if vhost
       params = Browser.append_params_header_field(
         params,
         'Host',
-        virtualHost
+        vhost
       )
     end
     

--- a/lib/wpscan/wp_target.rb
+++ b/lib/wpscan/wp_target.rb
@@ -28,11 +28,11 @@ class WpTarget < WebSite
     @wp_content_dir = options[:wp_content_dir]
     @wp_plugins_dir = options[:wp_plugins_dir]
     @multisite      = nil
-    @virtualHost = options[:virtualHost]
+    @vhost = options[:vhost]
 
     Browser.instance.referer = url
-    if @virtualHost
-      Browser.instance.virtualHost = @virtualHost
+    if @vhost
+      Browser.instance.vhost = @vhost
     end
 
   end

--- a/lib/wpscan/wp_target.rb
+++ b/lib/wpscan/wp_target.rb
@@ -28,8 +28,13 @@ class WpTarget < WebSite
     @wp_content_dir = options[:wp_content_dir]
     @wp_plugins_dir = options[:wp_plugins_dir]
     @multisite      = nil
+    @virtualHost = options[:virtualHost]
 
     Browser.instance.referer = url
+    if @virtualHost
+      Browser.instance.virtualHost = @virtualHost
+    end
+
   end
 
   # check if the target website is

--- a/lib/wpscan/wpscan_options.rb
+++ b/lib/wpscan/wpscan_options.rb
@@ -251,6 +251,7 @@ class WpscanOptions
   def self.get_opt_long
     GetoptLong.new(
       ['--url', '-u', GetoptLong::REQUIRED_ARGUMENT],
+      ['--virtualHost',GetoptLong::OPTIONAL_ARGUMENT],
       ['--enumerate', '-e', GetoptLong::OPTIONAL_ARGUMENT],
       ['--username', '-U', GetoptLong::REQUIRED_ARGUMENT],
       ['--usernames', GetoptLong::REQUIRED_ARGUMENT],

--- a/lib/wpscan/wpscan_options.rb
+++ b/lib/wpscan/wpscan_options.rb
@@ -19,7 +19,7 @@ class WpscanOptions
     :proxy_auth,
     :threads,
     :url,
-    :virtualHost,
+    :vhost,
     :wordlist,
     :force,
     :update,
@@ -62,8 +62,8 @@ class WpscanOptions
     @url = URI.parse(add_http_protocol(url)).to_s
   end
 
-  def virtualHost=(virtualhost)
-    @virtualHost = virtualhost
+  def vhost=(vhost)
+    @vhost = vhost
   end
 
   def threads=(threads)
@@ -251,7 +251,7 @@ class WpscanOptions
   def self.get_opt_long
     GetoptLong.new(
       ['--url', '-u', GetoptLong::REQUIRED_ARGUMENT],
-      ['--virtualHost',GetoptLong::OPTIONAL_ARGUMENT],
+      ['--vhost',GetoptLong::OPTIONAL_ARGUMENT],
       ['--enumerate', '-e', GetoptLong::OPTIONAL_ARGUMENT],
       ['--username', '-U', GetoptLong::REQUIRED_ARGUMENT],
       ['--usernames', GetoptLong::REQUIRED_ARGUMENT],

--- a/lib/wpscan/wpscan_options.rb
+++ b/lib/wpscan/wpscan_options.rb
@@ -19,6 +19,7 @@ class WpscanOptions
     :proxy_auth,
     :threads,
     :url,
+    :virtualHost,
     :wordlist,
     :force,
     :update,

--- a/lib/wpscan/wpscan_options.rb
+++ b/lib/wpscan/wpscan_options.rb
@@ -62,6 +62,10 @@ class WpscanOptions
     @url = URI.parse(add_http_protocol(url)).to_s
   end
 
+  def virtualHost=(virtualhost)
+    @virtualHost = virtualhost
+  end
+
   def threads=(threads)
     @threads = threads.is_a?(Integer) ? threads : threads.to_i
   end


### PR DESCRIPTION
Add support for virtual hosts
command line argument --virtualHost wordpress.mydomain.com will set the Host-header in requests to wordpress.mydomain.com

Allows you to test sites where the forward DNS lookup does not match the IP of the server you wish to test:
- old installation where the DNS has been changed to the new setup
- new test installation
- server behind a CDN where you want to bypass the CDN while testing
- ...

