### PR TITLE
Add --throttle option

### DIFF
--- a/lib/common/browser.rb
+++ b/lib/common/browser.rb
@@ -17,7 +17,8 @@ class Browser
     :proxy_auth,
     :request_timeout,
     :connect_timeout,
-    :cookie
+    :cookie,
+    :throttle
   ]
 
   @@instance = nil
@@ -76,6 +77,7 @@ class Browser
     @request_timeout = 60 # 60s
     @connect_timeout = 10 # 10s
     @user_agent = "WPScan v#{WPSCAN_VERSION} (http://wpscan.org)"
+    @throttle = 0
   end
 
   #
@@ -135,7 +137,7 @@ class Browser
         @basic_auth
       )
     end
-    
+
     if vhost
       params = Browser.append_params_header_field(
         params,
@@ -143,7 +145,7 @@ class Browser
         vhost
       )
     end
-    
+
     params.merge!(referer: referer)
     params.merge!(timeout: @request_timeout) if @request_timeout
     params.merge!(connecttimeout: @connect_timeout) if @connect_timeout
@@ -163,6 +165,14 @@ class Browser
     params.merge!(cookie: @cookie) if @cookie
 
     params
+  end
+
+  def throttle=(val)
+    @throttle = val.to_i / 1000.0
+  end
+
+  def throttle!
+    sleep @throttle
   end
 
   private

--- a/lib/common/browser/actions.rb
+++ b/lib/common/browser/actions.rb
@@ -44,6 +44,7 @@ class Browser
     #
     # @return [ Typhoeus::Response ]
     def process(url, params)
+      Browser.instance.throttle!
       Typhoeus::Request.new(url, Browser.instance.merge_request_params(params)).run
     end
 

--- a/lib/common/collections/wp_items/detectable.rb
+++ b/lib/common/collections/wp_items/detectable.rb
@@ -43,6 +43,8 @@ class WpItems < Array
           hydra.run
           queue_count = 0
           puts "Sent #{browser.max_threads} requests ..." if options[:verbose]
+
+          browser.throttle!
         end
       end
 

--- a/lib/common/models/wp_user/brute_forcable.rb
+++ b/lib/common/models/wp_user/brute_forcable.rb
@@ -58,6 +58,8 @@ class WpUser < WpItem
           hydra.run
           queue_count = 0
           puts "Sent #{browser.max_threads} requests ..." if options[:verbose]
+
+          browser.throttle!
         end
       end
 

--- a/lib/wpscan/wp_target/wp_config_backup.rb
+++ b/lib/wpscan/wp_target/wp_config_backup.rb
@@ -29,6 +29,8 @@ class WpTarget < WebSite
         if queue_count == browser.max_threads
           hydra.run
           queue_count = 0
+
+          browser.throttle!
         end
       end
 
@@ -40,7 +42,7 @@ class WpTarget < WebSite
     # @return [ Array ]
     def self.config_backup_files
       %w{
-        wp-config.php~ #wp-config.php# wp-config.php.save .wp-config.php.swp wp-config.php.swp wp-config.php.swo 
+        wp-config.php~ #wp-config.php# wp-config.php.save .wp-config.php.swp wp-config.php.swp wp-config.php.swo
         wp-config.php_bak wp-config.bak wp-config.php.bak wp-config.save wp-config.old wp-config.php.old
         wp-config.php.orig wp-config.orig wp-config.php.original wp-config.original wp-config.txt
       } # thanks to Feross.org for these

--- a/lib/wpscan/wpscan_options.rb
+++ b/lib/wpscan/wpscan_options.rb
@@ -43,7 +43,8 @@ class WpscanOptions
     :request_timeout,
     :connect_timeout,
     :max_threads,
-    :no_banner
+    :no_banner,
+    :throttle
   ]
 
   attr_accessor *ACCESSOR_OPTIONS
@@ -281,7 +282,8 @@ class WpscanOptions
       ['--no-color', GetoptLong::NO_ARGUMENT],
       ['--cookie', GetoptLong::REQUIRED_ARGUMENT],
       ['--log', GetoptLong::NO_ARGUMENT],
-      ['--no-banner', GetoptLong::NO_ARGUMENT]
+      ['--no-banner', GetoptLong::NO_ARGUMENT],
+      ['--throttle', GetoptLong::REQUIRED_ARGUMENT]
     )
   end
 


### PR DESCRIPTION
I needed this feature quickly (it was also requested in #775) so it isn't probably the best way to implement this.

This options allow to throttle requests made by WPScan by a specified number of milliseconds. This should be used with --threads/--max-threads set to 1.

Some whitespace was also trimmed in the process.