### PR TITLE
Add support for local-directory scanning

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = spaces
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,11 @@ source 'https://rubygems.org'
 gem 'typhoeus', '~>0.8.0'
 gem 'nokogiri'
 gem 'addressable'
-gem 'yajl-ruby' # Better JSON parser regarding memory usage
+if defined?(JRUBY_VERSION)
+  gem 'json'
+else
+  gem 'yajl-ruby' # Better JSON parser regarding memory usage
+end
 # TODO: update the below when terminal-table 1.5.3+ is released.
 # (and delete the Terminal module in lib/common/hacks.rb)
 gem 'terminal-table', '~>1.4.5'

--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ Apple Xcode, Command Line Tools and the libffi are needed (to be able to install
                                         Subdirectories are allowed.
     --wp-plugins-dir <wp plugins dir>   Same thing than --wp-content-dir but for the plugins directory.
                                         If not supplied, WPScan will use wp-content-dir/plugins. Subdirectories are allowed
+    --wp-local-dir <wp local dir>       Optional local path of WordPress installation. If this is
+                                        specified it can skip doing HTTP checks for enumeration and
+                                        check directly in the FS.
     --proxy <[protocol://]host:port>    Supply a proxy. HTTP, SOCKS4 SOCKS4A and SOCKS5 are supported.
                                         If no protocol is given (format host:port), HTTP will be used.
     --proxy-auth <username:password>    Supply the proxy login credentials.

--- a/lib/common/collections/wp_items.rb
+++ b/lib/common/collections/wp_items.rb
@@ -53,7 +53,8 @@ class WpItems < Array
       attrs.merge(
         name: name,
         wp_content_dir: wp_target.wp_content_dir,
-        wp_plugins_dir: wp_target.wp_plugins_dir
+        wp_plugins_dir: wp_target.wp_plugins_dir,
+        wp_local_dir: wp_target.wp_local_dir
       ) { |key, oldval, newval| oldval }
     )
   end

--- a/lib/common/collections/wp_items/detectable.rb
+++ b/lib/common/collections/wp_items/detectable.rb
@@ -23,6 +23,7 @@ class WpItems < Array
         homepage_hash:   wp_target.homepage_hash,
         exclude_content: options[:exclude_content] ? %r{#{options[:exclude_content]}} : nil
       }
+
       results          = passive_detection(wp_target, options)
 
       targets.each do |target_item|
@@ -53,6 +54,26 @@ class WpItems < Array
       results.sort!
 
       results  # can't just return results.sort as it would return an array, and we want a WpItems
+    end
+    
+    # @param [ WpTarget ] wp_target
+    # @param [ Hash ] options
+    # @option options [ Boolean ] :only_vulnerable   Only check for vulnerable items
+    #
+    # @return [ WpItems ]
+    def directory_detection(wp_target, options)
+      results       = passive_detection(wp_target, options)
+      targets       = targets_items(wp_target, options)
+      
+      targets.each do |target_item|
+        if target_item.exists_from_path?
+          results << target_item unless results.include?(target_item)
+        end
+      end
+      
+      results.select!(&:vulnerable?) if options[:type] == :vulnerable
+      results.sort!
+      results
     end
 
     # @param [ Integer ] targets_size
@@ -201,7 +222,8 @@ class WpItems < Array
         name:           name,
         vulns_file:     vulns_file,
         wp_content_dir: wp_target.wp_content_dir,
-        wp_plugins_dir: wp_target.wp_plugins_dir
+        wp_plugins_dir: wp_target.wp_plugins_dir,
+        wp_local_dir:   wp_target.wp_local_dir
       )
     end
 

--- a/lib/common/collections/wp_timthumbs/detectable.rb
+++ b/lib/common/collections/wp_timthumbs/detectable.rb
@@ -72,7 +72,8 @@ class WpTimthumbs < WpItems
     def create_item(wp_target, path = nil)
       options = {
         wp_content_dir: wp_target.wp_content_dir,
-        wp_plugins_dir: wp_target.wp_plugins_dir
+        wp_plugins_dir: wp_target.wp_plugins_dir,
+        wp_local_dir: wp_target.wp_local_dir
       }
 
       options.merge!(path: path) if path

--- a/lib/common/models/wp_item.rb
+++ b/lib/common/models/wp_item.rb
@@ -17,12 +17,12 @@ class WpItem
   include WpItem::Output
 
   attr_reader   :path
-  attr_accessor :name, :wp_content_dir, :wp_plugins_dir
+  attr_accessor :name, :wp_content_dir, :wp_plugins_dir, :wp_local_dir
 
   # @return [ Array ]
   # Make it private ?
   def allowed_options
-    [:name, :wp_content_dir, :wp_plugins_dir, :path, :version, :db_file]
+    [:name, :wp_content_dir, :wp_plugins_dir, :wp_local_dir, :path, :version, :db_file]
   end
 
   # @param [ URI ] target_base_uri
@@ -32,6 +32,7 @@ class WpItem
   def initialize(target_base_uri, options = {})
     options[:wp_content_dir] ||= 'wp-content'
     options[:wp_plugins_dir] ||= options[:wp_content_dir] + '/plugins'
+    options[:wp_local_dir]   ||= ''
 
     set_options(options)
     forge_uri(target_base_uri)

--- a/lib/common/models/wp_item/existable.rb
+++ b/lib/common/models/wp_item/existable.rb
@@ -3,7 +3,10 @@
 class WpItem
   module Existable
 
-    # Check the existence of the WpItem
+    # Check the existence of the WpItem.
+    # If the wp_item is tied to a target using a local WPdirectory, it just
+    # returns if the plugin exists in that WP file system.
+    #
     # If the response is supplied, it's used for the verification
     # Otherwise a new request is done
     #
@@ -18,6 +21,18 @@ class WpItem
       exists_from_response?(response, options)
     end
 
+    # @return [ Boolean ]
+    def exists_from_path?()
+      unless wp_local_dir.to_s and uri.path.to_s
+        false
+      end
+      
+      haystack = File.expand_path(wp_local_dir.to_s)
+      needle = File.join(haystack, File.expand_path(uri.path.to_s))
+      
+      not File.identical?(needle, haystack) and File.directory?(needle)
+    end
+    
     protected
 
     # @param [ Typhoeus::Response ] response

--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -31,7 +31,12 @@ begin
   require 'pathname'
   # Third party libs
   require 'typhoeus'
-  require 'yajl/json_gem'
+  begin
+    require 'yajl/json_gem'
+  rescue LoadError
+    # Require basic json library if yajl is not available
+    require 'json'
+  end
   require 'nokogiri'
   require 'terminal-table'
   require 'ruby-progressbar'

--- a/lib/wpscan/wp_target.rb
+++ b/lib/wpscan/wp_target.rb
@@ -27,6 +27,7 @@ class WpTarget < WebSite
     @verbose        = options[:verbose]
     @wp_content_dir = options[:wp_content_dir]
     @wp_plugins_dir = options[:wp_plugins_dir]
+    @wp_local_dir   = File.expand_path(options[:wp_local_dir].to_s)
     @multisite      = nil
     @vhost = options[:vhost]
 
@@ -35,6 +36,11 @@ class WpTarget < WebSite
       Browser.instance.vhost = @vhost
     end
 
+  end
+  
+  # @return [ String ] The local directory of a WP install
+  def wp_local_dir
+    @wp_local_dir
   end
 
   # check if the target website is

--- a/lib/wpscan/wpscan_options.rb
+++ b/lib/wpscan/wpscan_options.rb
@@ -29,6 +29,7 @@ class WpscanOptions
     :follow_redirection,
     :wp_content_dir,
     :wp_plugins_dir,
+    :wp_local_dir,
     :help,
     :config_file,
     :cookie,
@@ -282,7 +283,8 @@ class WpscanOptions
       ['--cookie', GetoptLong::REQUIRED_ARGUMENT],
       ['--log', GetoptLong::NO_ARGUMENT],
       ['--no-banner', GetoptLong::NO_ARGUMENT],
-      ['--throttle', GetoptLong::REQUIRED_ARGUMENT]
+      ['--throttle', GetoptLong::REQUIRED_ARGUMENT],
+      ['--wp-local-dir', GetoptLong::REQUIRED_ARGUMENT],
     )
   end
 

--- a/spec/lib/common/collections/wp_items_spec.rb
+++ b/spec/lib/common/collections/wp_items_spec.rb
@@ -18,7 +18,9 @@ describe WpItems do
         vulnerable_targets_items: [ WpItem.new(uri, name: 'mr-smith'),
                                     WpItem.new(uri, name: 'neo')],
 
-        passive_detection: (1..13).reduce(WpItems.new) { |o, i| o << WpItem.new(uri, name: "detect-me-#{i}") }
+        passive_detection: (1..13).reduce(WpItems.new) { |o, i| o << WpItem.new(uri, name: "detect-me-#{i}") },
+        
+        directory_detection:      [ WpPlugin.new(uri, name: 'mr-smith', wp_local_dir: wp_local_dir) ]
       }
     end
   end

--- a/spec/lib/common/collections/wp_plugins_spec.rb
+++ b/spec/lib/common/collections/wp_plugins_spec.rb
@@ -23,7 +23,9 @@ describe WpPlugins do
                                             WpPlugin.new(uri, name: 'link-tag') <<
                                             WpPlugin.new(uri, name: 'script-tag') <<
                                             WpPlugin.new(uri, name: 'style-tag') <<
-                                            WpPlugin.new(uri, name: 'style-tag-import')
+                                            WpPlugin.new(uri, name: 'style-tag-import'),
+
+        directory_detection:              [ WpPlugin.new(uri, name: 'mr-smith', wp_local_dir: wp_local_dir) ]
       }
     end
   end

--- a/spec/lib/common/collections/wp_themes_spec.rb
+++ b/spec/lib/common/collections/wp_themes_spec.rb
@@ -24,7 +24,9 @@ describe WpThemes do
         passive_detection: WpThemes.new << WpTheme.new(uri, name: 'theme1') <<
                                            WpTheme.new(uri, name: 'theme 2') <<
                                            WpTheme.new(uri, name: 'theme-3') <<
-                                           WpTheme.new(uri, name: 'style-tag-import')
+                                           WpTheme.new(uri, name: 'style-tag-import'),
+                                          
+        directory_detection:             [ WpTheme.new(uri, name: 'mr-smith', wp_local_dir: wp_local_dir) ]
       }
     end
   end

--- a/spec/samples/wpscan/wp_local_dir/wp-content/plugins/mr-smith/readme.txt
+++ b/spec/samples/wpscan/wp_local_dir/wp-content/plugins/mr-smith/readme.txt
@@ -1,0 +1,2 @@
+=== Mr Smith ===
+Stable tag: 3.8.1

--- a/spec/samples/wpscan/wp_local_dir/wp-content/themes/mr-smith/readme.txt
+++ b/spec/samples/wpscan/wp_local_dir/wp-content/themes/mr-smith/readme.txt
@@ -1,0 +1,2 @@
+=== Mr Smith ===
+Stable tag: 3.8.1

--- a/wpscan.rb
+++ b/wpscan.rb
@@ -288,13 +288,23 @@ def main
         plugin_enumeration_type = :all
       end
       puts
-
-      wp_plugins = WpPlugins.aggressive_detection(wp_target,
-        enum_options.merge(
-          file: PLUGINS_FILE,
-          type: plugin_enumeration_type
+      
+      if wpscan_options.wp_local_dir
+        puts info("Using local WordPress directory for enumeration")
+        wp_plugins = WpPlugins.directory_detection(wp_target,
+          enum_options.merge(
+            file: PLUGINS_FILE,
+            type: plugin_enumeration_type
+          )
         )
-      )
+      else
+        wp_plugins = WpPlugins.aggressive_detection(wp_target,
+          enum_options.merge(
+            file: PLUGINS_FILE,
+            type: plugin_enumeration_type
+          )
+        )
+      end
 
       puts
       if !wp_plugins.empty?


### PR DESCRIPTION
Add support for scanning local WP installation directory for plugins
This can be helpful if you don't want to hit your server with a ton of requests at once.
It behaves the same way but just checks for directory existance of a plugin / theme, etc.

Use by setting `--wp-local-dir`, i.e.

````
ruby wpscan.rb --url google.com --enumerate vp --wp-local-dir /repositories/google/web
````
