### PR TITLE
change hardcoded `require` path to relative

### DIFF
--- a/wpscan.rb
+++ b/wpscan.rb
@@ -5,7 +5,7 @@ $: << '.'
 
 $exit_code = 0
 
-require File.dirname(__FILE__) + '/lib/wpscan/wpscan_helper'
+require_relative 'lib/wpscan/wpscan_helper'
 
 def main
   # delete old logfile, check if it is a symlink first.


### PR DESCRIPTION
This allows the file to be executed from a symlink.