### PR TITLE
more advanced version detection

### DIFF
--- a/lib/common/models/wp_item/findable.rb
+++ b/lib/common/models/wp_item/findable.rb
@@ -9,7 +9,7 @@ class WpItem
   #
   # @return [ void ]
   def found_from=(method)
-    @found_from = method.to_s.to_s.gsub(/find_from_/, '').gsub(/_/, ' ')
+    @found_from = method.to_s.gsub(/find_from_/, '').gsub(/_/, ' ')
   end
 
   module Findable

--- a/lib/common/models/wp_item/findable.rb
+++ b/lib/common/models/wp_item/findable.rb
@@ -9,8 +9,7 @@ class WpItem
   #
   # @return [ void ]
   def found_from=(method)
-    found       = method[%r{find_from_(.*)}, 1]
-    @found_from = found.gsub('_', ' ') if found
+    @found_from = method.to_s.to_s.gsub(/find_from_/, '').gsub(/_/, ' ')
   end
 
   module Findable

--- a/lib/common/models/wp_theme/findable.rb
+++ b/lib/common/models/wp_theme/findable.rb
@@ -11,7 +11,7 @@ class WpTheme < WpItem
     def find(target_uri)
       methods.grep(/^find_from_/).each do |method|
         if wp_theme = self.send(method, target_uri)
-          wp_theme.found_from = method
+          wp_theme.found_from = method.to_s
 
           return wp_theme
         end

--- a/lib/common/models/wp_version/findable.rb
+++ b/lib/common/models/wp_version/findable.rb
@@ -12,6 +12,7 @@ class WpVersion < WpItem
     #
     # @return [ WpVersion ]
     def find(target_uri, wp_content_dir, wp_plugins_dir, versions_xml)
+      versions = {}
       methods.grep(/^find_from_/).each do |method|
 
         if method === :find_from_advanced_fingerprinting
@@ -21,9 +22,21 @@ class WpVersion < WpItem
         end
 
         if version
-          return new(target_uri, number: version, found_from: method)
+          if versions.key?(version)
+            versions[version] << method.to_s
+          else
+            versions[version] = [ method.to_s ]
+          end
         end
       end
+
+      if versions.length > 0
+        determined_version = versions.max_by { |k, v| v.length }
+        if determined_version
+          return new(target_uri, number: determined_version[0], found_from: determined_version[1].join(', '))
+        end
+      end
+
       nil
     end
 

--- a/lib/common/models/wp_version/output.rb
+++ b/lib/common/models/wp_version/output.rb
@@ -12,7 +12,7 @@ class WpVersion < WpItem
         puts " | Released: #{metadata[:release_date]}"
         puts " | Changelog: #{metadata[:changelog_url]}"
       else
-        puts info("WordPress version #{self.number} identified from #{self.found_from} #{"(Released on #{metadata[:release_date]})" if metadata[:release_date]}")
+        puts info("WordPress version #{self.number} #{"(Released on #{metadata[:release_date]}) identified from #{self.found_from}" if metadata[:release_date]}")
       end
 
       vulnerabilities = self.vulnerabilities

--- a/spec/shared_examples/wp_item_findable_found_from.rb
+++ b/spec/shared_examples/wp_item_findable_found_from.rb
@@ -7,12 +7,6 @@ shared_examples 'WpItem::Findable#Found_From=' do
       subject.found_from = @method
       expect(subject.found_from).to eq @expected
     end
-    context 'when the pattern is not found' do
-      it 'returns nil' do
-        @method   = 'I_do_not_match'
-        @expected = nil
-      end
-    end
 
     it 'replaces _ by space' do
       @method   = 'find_from_some_detection_method'


### PR DESCRIPTION
Before: The first version hit returns the version
Now: All finders are executed and the version with the most matches is selected