### PR TITLE
bump terminal-table to 1.6.0 and drop workaround

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,7 @@ gem 'typhoeus', '>=0.8.0'
 gem 'nokogiri', '>=1.6.7.2'
 gem 'addressable'
 gem 'yajl-ruby' # Better JSON parser regarding memory usage
-# TODO: update the below when terminal-table 1.5.3+ is released.
-# See issue #841 for details
-# (and delete the Terminal module in lib/common/hacks.rb)
-gem 'terminal-table', '~>1.4.5'
+gem 'terminal-table', '>=1.6.0'
 gem 'ruby-progressbar', '>=1.6.0'
 
 group :test do

--- a/lib/common/hacks.rb
+++ b/lib/common/hacks.rb
@@ -27,47 +27,6 @@ def puts(o = '')
   super(o)
 end
 
-module Terminal
-  class Table
-    def render
-      separator = Separator.new(self)
-      buffer = [separator]
-      unless @title.nil?
-        buffer << Row.new(self, [title_cell_options])
-        buffer << separator
-      end
-      unless @headings.cells.empty?
-        buffer << @headings
-        buffer << separator
-      end
-      buffer += @rows
-      buffer << separator
-      buffer.map { |r| style.margin_left + r.render }.join("\n")
-    end
-    alias :to_s :render
-
-    class Style
-      @@defaults = {
-        :border_x => '-', :border_y => '|', :border_i => '+',
-        :padding_left => 1, :padding_right => 1,
-        :margin_left => '',
-        :width => nil, :alignment => nil
-      }
-
-      attr_accessor :margin_left
-      attr_accessor :border_x
-      attr_accessor :border_y
-      attr_accessor :border_i
-
-      attr_accessor :padding_left
-      attr_accessor :padding_right
-
-      attr_accessor :width
-      attr_accessor :alignment
-    end
-  end
-end
-
 class Numeric
   def bytes_to_human
     units = %w{B KB MB GB TB}


### PR DESCRIPTION
a new version of terminal-table has been released that makes the version pinning and workaround obsolete