### PR TITLE
Enable --cache-dir option in command line parameters, which solves write permission issues when wpscan is installed in system or root-owned directories

### DIFF
--- a/lib/wpscan/wpscan_options.rb
+++ b/lib/wpscan/wpscan_options.rb
@@ -45,7 +45,8 @@ class WpscanOptions
     :no_banner,
     :throttle,
     :disable_accept_header,
-    :disable_referer
+    :disable_referer,
+    :cache_dir
   ]
 
   attr_accessor *ACCESSOR_OPTIONS
@@ -288,7 +289,8 @@ class WpscanOptions
       ['--no-banner', GetoptLong::NO_ARGUMENT],
       ['--throttle', GetoptLong::REQUIRED_ARGUMENT],
       ['--disable-accept-header', GetoptLong::NO_ARGUMENT],
-      ['--disable-referer', GetoptLong::NO_ARGUMENT]
+      ['--disable-referer', GetoptLong::NO_ARGUMENT],
+      ['--cache-dir', GetoptLong::REQUIRED_ARGUMENT]
     )
   end
 


### PR DESCRIPTION
## Overview :

This pull request just adds two lines to `wpscan_options.rb`, allowing users to pass a `--cache-dir` option from the command line. An example would be : `ruby wpscan.rb --url="http://example.com" --cache-dir="~/.wpscan/cache"`

## Further explanations :

Currently, wpscan writes the browser cache in its own directory `./cache/browser/`. This causes write permission errors when wpscan is installed in a system root directory such as `/usr/share/wpscan/` or `/usr/lib/wpscan/` and then executed by a user who doesn't have the permissions to write inside those directories.

Obviously, we don't want to grant write permission to non-root users in such directories, so we need to allow wpscan execution to write cache elsewhere.

Because the `browser.rb` Browser class takes its option array from the command line, we just need to allow a --cache-dir parameter to be passed when executing wpscan, which is what we added here.