### PR TITLE
Avoid false-positive detection of plugins and themes

### DIFF
--- a/lib/common/collections/wp_items/detectable.rb
+++ b/lib/common/collections/wp_items/detectable.rb
@@ -19,8 +19,7 @@ class WpItems < Array
       progress_bar     = progress_bar(targets.size, options)
       queue_count      = 0
       exist_options    = {
-        error_404_hash:  wp_target.error_404_hash,
-        homepage_hash:   wp_target.homepage_hash,
+        error_404_hash_set:  wp_target.error_404_hash_set,
         exclude_content: options[:exclude_content] ? %r{#{options[:exclude_content]}} : nil
       }
       results          = passive_detection(wp_target, options)

--- a/lib/common/hacks.rb
+++ b/lib/common/hacks.rb
@@ -4,14 +4,16 @@
 module Typhoeus
   class Response
 
-    # Compare the body hash to error_404_hash and homepage_hash
-    # returns true if they are different, false otherwise
+    # Compare the body hash to error_404_hash_set and homepage_hash
+    # returns true if it does not match known hashes, false otherwise
     #
     # @return [ Boolean ]
-    def has_valid_hash?(error_404_hash, homepage_hash)
+    def has_valid_hash?(error_404_hash_set, homepage_hash)
       body_hash = WebSite.page_hash(self)
 
-      body_hash != error_404_hash && body_hash != homepage_hash
+      return false if error_404_hash_set && error_404_hash_set.include?(body_hash)
+      return false if body_hash == homepage_hash
+      return true
     end
 
   end

--- a/lib/common/models/wp_item/existable.rb
+++ b/lib/common/models/wp_item/existable.rb
@@ -23,7 +23,7 @@ class WpItem
     # @param [ Typhoeus::Response ] response
     # @param [ options ] options
     #
-    # @option options [ Hash ] :error_404_hash  The hash of the error 404 page
+    # @option options [ Hash ] :error_404_hash_set  The set of the hash of 404 pages
     # @option options [ Hash ] :homepage_hash   The hash of the homepage
     # @option options [ Hash ] :exclude_content A regexp with the pattern to exclude from the body of the response
     #
@@ -31,9 +31,9 @@ class WpItem
     def exists_from_response?(response, options = {})
       # 301 included as some items do a self-redirect
       # Redirects to the 404 and homepage should be ignored (unless dynamic content is used)
-      # by the page hashes (error_404_hash & homepage_hash)
+      # by the page hashes (error_404_hash_set & homepage_hash)
       if [200, 401, 403, 301].include?(response.code)
-        if response.has_valid_hash?(options[:error_404_hash], options[:homepage_hash])
+        if response.has_valid_hash?(options[:error_404_hash_set], options[:homepage_hash])
           if options[:exclude_content]
             unless response.body.match(options[:exclude_content])
               return true

--- a/lib/wpscan/web_site.rb
+++ b/lib/wpscan/web_site.rb
@@ -113,12 +113,12 @@ class WebSite
   end
 
   # Return the MD5 hash of a 404 page
-  def error_404_hash
-    unless @error_404_hash
+  def site_404_hash
+    unless @site_404_hash
       non_existant_page = Digest::MD5.hexdigest(rand(999_999_999).to_s) + '.html'
-      @error_404_hash   = WebSite.page_hash(@uri.merge(non_existant_page).to_s)
+      @site_404_hash    = WebSite.page_hash(@uri.merge(non_existant_page).to_s)
     end
-    @error_404_hash
+    @site_404_hash
   end
 
   # Will try to find the rss url in the homepage

--- a/lib/wpscan/wp_target.rb
+++ b/lib/wpscan/wp_target.rb
@@ -190,9 +190,9 @@ class WpTarget < WebSite
     unless @error_404_hash_set
       hash_set = Set.new([site_404_hash])
 
-      non_existant_page = Digest::MD5.hexdigest(rand(999_999_999).to_s) + '.html'
+      non_existent_page = Digest::MD5.hexdigest(rand(999_999_999).to_s) + '.html'
       [wp_content_dir, wp_plugins_dir, wp_themes_dir].each do |dir|
-        hash_set << WebSite.page_hash(@uri.merge("#{dir}/#{non_existant_page}"))
+        hash_set << WebSite.page_hash(@uri.merge("#{dir}/#{non_existent_page}"))
       end
       @error_404_hash_set = hash_set.freeze
     end

--- a/lib/wpscan/wp_target.rb
+++ b/lib/wpscan/wp_target.rb
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+require 'set'
 require 'web_site'
 require 'wp_target/wp_readme'
 require 'wp_target/wp_registrable'
@@ -176,5 +177,25 @@ class WpTarget < WebSite
 
   def include_directory_listing_enabled?
     directory_listing_enabled?(includes_dir_url)
+  end
+
+  # Return the set of 404 error page hash for wp-content directories.
+  #
+  # This set is useful to check if a plugin or a theme is installed
+  # because 404 error pages for non-existent items can be different from
+  # target's default because of some plugin(i.e. IP Geo Block).
+  #
+  # @return [ Set<String> ]
+  def error_404_hash_set
+    unless @error_404_hash_set
+      hash_set = Set.new([site_404_hash])
+
+      non_existant_page = Digest::MD5.hexdigest(rand(999_999_999).to_s) + '.html'
+      [wp_content_dir, wp_plugins_dir, wp_themes_dir].each do |dir|
+        hash_set << WebSite.page_hash(@uri.merge("#{dir}/#{non_existant_page}"))
+      end
+      @error_404_hash_set = hash_set.freeze
+    end
+    @error_404_hash_set
   end
 end

--- a/lib/wpscan/wp_target/wp_custom_directories.rb
+++ b/lib/wpscan/wp_target/wp_custom_directories.rb
@@ -26,7 +26,7 @@ class WpTarget < WebSite
 
       if WpTarget.valid_response_codes.include?(response.code)
         hash = WebSite.page_hash(response)
-        return true if hash != error_404_hash and hash != homepage_hash
+        return true if hash != site_404_hash and hash != homepage_hash
       end
 
       false
@@ -43,6 +43,14 @@ class WpTarget < WebSite
     # @return [ Boolean ]
     def wp_plugins_dir_exists?
       Browser.get(@uri.merge(wp_plugins_dir).to_s).code != 404
+    end
+
+    # @return [ String ] The wp-themes directory
+    def wp_themes_dir
+      unless @wp_themes_dir
+        @wp_themes_dir = "#{wp_content_dir}/themes"
+      end
+      @wp_themes_dir
     end
 
   end

--- a/lib/wpscan/wp_target/wp_must_use_plugins.rb
+++ b/lib/wpscan/wp_target/wp_must_use_plugins.rb
@@ -10,7 +10,7 @@ class WpTarget < WebSite
 
       if response && [200, 401, 403].include?(response.code)
         hash = WebSite.page_hash(response)
-        return true if hash != error_404_hash && hash != homepage_hash
+        return true if hash != site_404_hash && hash != homepage_hash
       end
 
       false

--- a/lib/wpscan/wp_target/wp_must_use_plugins.rb
+++ b/lib/wpscan/wp_target/wp_must_use_plugins.rb
@@ -9,8 +9,7 @@ class WpTarget < WebSite
       response = Browser.get(must_use_url)
 
       if response && [200, 401, 403].include?(response.code)
-        hash = WebSite.page_hash(response)
-        return true if hash != site_404_hash && hash != homepage_hash
+        return true if response.has_valid_hash?(error_404_hash_set, homepage_hash)
       end
 
       false

--- a/spec/lib/wpscan/web_site_spec.rb
+++ b/spec/lib/wpscan/web_site_spec.rb
@@ -198,12 +198,12 @@ describe 'WebSite' do
     end
   end
 
-  describe '#error_404_hash' do
+  describe '#site_404_hash' do
     it 'returns the md5sum of the 404 page' do
       stub_request(:any, /.*/).
         to_return(status: 404, body: '404 page !')
 
-      expect(web_site.error_404_hash).to be === Digest::MD5.hexdigest('404 page !')
+      expect(web_site.site_404_hash).to be === Digest::MD5.hexdigest('404 page !')
     end
   end
 

--- a/spec/lib/wpscan/wp_target_spec.rb
+++ b/spec/lib/wpscan/wp_target_spec.rb
@@ -215,4 +215,16 @@ describe WpTarget do
     end
   end
 
+  describe '#error_404_hash_set' do
+    it 'returns a set of error 404 pages' do
+      allow(wp_target).to receive_messages(:site_404_hash => Digest::MD5.hexdigest('site 404'))
+      stub_request(:any, %r{wp-content/[^/]+.html}).to_return(status: 200, body: 'wp-content 404')
+      stub_request(:any, %r{wp-content/plugins/[^/]+.html}).to_return(status: 200, body: 'plugin 404')
+      stub_request(:any, %r{wp-content/themes/[^/]+.html}).to_return(status: 200, body: 'theme 404')
+
+      expected = ['site 404', 'wp-content 404', 'plugin 404', 'theme 404'].map{ |body| Digest::MD5.hexdigest(body) }.to_set
+      expect(wp_target.error_404_hash_set).to eq expected
+    end
+  end
+
 end

--- a/spec/shared_examples/wp_item_existable.rb
+++ b/spec/shared_examples/wp_item_existable.rb
@@ -41,8 +41,17 @@ shared_examples 'WpItem::Existable' do
       end
     end
 
-    context 'when the body hash = homepage_hash or error_404_hash' do
+    context 'when the body hash = homepage_hash' do
       let(:exists_options) { { homepage_hash: Digest::MD5.hexdigest(body) } }
+
+      it 'returns false' do
+        @resp_opt = { code: 200, body: body }
+        @expected = false
+      end
+    end
+
+    context 'when the body hash is included in error_404_hash_set' do
+      let(:exists_options) { { error_404_hash_set: Set.new([Digest::MD5.hexdigest(body)]) } }
 
       it 'returns false' do
         @resp_opt = { code: 200, body: body }


### PR DESCRIPTION
I found WPScan can misdetect too many non-existant plugins/themes under the following conditions.
- A target server returns `403` instead of `404` when requested plugins/themes URL doesn't exist
- The response bodies of such requests deffer from ordinary 404 response

This problem occurs when accesses to non-existant file under plugins/themes directories are explicitly prohibited by server settings.

On such situation, the server returns 403 response and its hash does not match ordinary 404 response, so `WpItem::Existable::exists_from_response?` can't tell whether a plugin exists or accesses are simply restricted. As a result, all plugins/themes are output as found. 
