### PR TITLE
[fix]  wpscan_helpfer file haven't found when linking wpscan 

### DIFF
--- a/wpscan.rb
+++ b/wpscan.rb
@@ -5,7 +5,8 @@ $: << '.'
 
 $exit_code = 0
 
-require File.dirname(__FILE__) + '/lib/wpscan/wpscan_helper'
+wpscan_helper_path = File.join(File.realdirpath(__dir__), 'lib', 'wpscan', 'wpscan_helper')
+require wpscan_helper_path
 
 def main
   # delete old logfile, check if it is a symlink first.


### PR DESCRIPTION
**wpscan_helper** file haven't found when linking wpscan to another directory and this condition causes an library requirement error.

Before Fix;
```
$ ln -s /wpscan/wpscan.rb /usr/local/bin/wpscan
$ wpscan --version
/usr/local/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- /usr/local/bin/lib/wpscan/wpscan_helper (LoadError)
	from /usr/local/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/local/bin/wpscan:8:in `<main>'
```

After Fix;
```
$ ln -s /wpscan/wpscan.rb /usr/local/bin/wpscan
$ wpscan --version
_______________________________________________________________
        __          _______   _____                  
        \ \        / /  __ \ / ____|                 
         \ \  /\  / /| |__) | (___   ___  __ _ _ __  
          \ \/  \/ / |  ___/ \___ \ / __|/ _` | '_ \ 
           \  /\  /  | |     ____) | (__| (_| | | | |
            \/  \/   |_|    |_____/ \___|\__,_|_| |_|

        WordPress Security Scanner by the WPScan Team 
                       Version 2.9.1
          Sponsored by Sucuri - https://sucuri.net
   @_WPScan_, @ethicalhack3r, @erwan_lr, pvdl, @_FireFart_
_______________________________________________________________

Current version: 2.9.1
Last DB update: 2016-10-05
```