### PR TITLE
Alpine based smaller docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,17 @@
-FROM ruby:2.3-slim
+FROM alpine:3.4
 MAINTAINER WPScan Team <team@wpscan.org>
 
-RUN DEBIAN_FRONTEND=noninteractive && \
-  rm -rf /var/lib/apt/lists/* && \
-  apt-get update && \
-  apt-get --no-install-recommends -qq -y install curl git ca-certificates openssl libcurl4-openssl-dev libxml2 libxml2-dev libxslt1-dev build-essential procps
-
-RUN useradd -d /wpscan wpscan
-RUN echo "gem: --no-ri --no-rdoc" > /etc/gemrc
 RUN mkdir /wpscan
-
-COPY . /wpscan
-
 WORKDIR /wpscan
 
-RUN bundle install --without test
-RUN chown -R wpscan:wpscan /wpscan
+RUN echo "gem: --no-ri --no-rdoc" > /etc/gemrc
+COPY Gemfile /wpscan
 
-USER wpscan
+RUN apk add --no-cache ruby libcurl ruby-dev ruby-bundler libffi-dev make gcc musl-dev zlib-dev procps && \
+  bundle install --without test && \
+  apk del --purge ruby-dev libffi-dev make gcc musl-dev zlib-dev
+
+COPY . /wpscan
 RUN /wpscan/wpscan.rb --update --verbose --no-color
 
 ENTRYPOINT ["/wpscan/wpscan.rb"]


### PR DESCRIPTION
I am not sure whether it is desired, but if so, here is a docker build based on Alpine rather than the ruby:2.3-slim image. It finishes at 92.35MB instead of 573.7MB.

The biggest question that I have with this is why the wpscan user/group were created in the original image. I couldn't find anything that doesn't worked because of running things as root instead, but I can add that back in if necessary.

![screen shot 2016-11-22 at 8 18 16 am](https://cloud.githubusercontent.com/assets/288935/20514508/9d05c8c4-b08c-11e6-9c89-dcdf8c918659.png)
