### PR TITLE
Add gcc to Debian prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Windows is not supported
 
 ### Installing dependencies on Debian
 
-    sudo apt-get install git ruby ruby-dev libcurl4-openssl-dev make zlib1g-dev
+    sudo apt-get install gcc git ruby ruby-dev libcurl4-openssl-dev make zlib1g-dev
 
 ### Installing dependencies on Fedora
 


### PR DESCRIPTION
This is needed to install some gems and mirrors the fact that gcc is included in the command lines Fedora and Ubuntu (there contained in `build-essential`).