### PR TITLE
'gem install readline' issues fix

### DIFF
--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -14,6 +14,7 @@ Encoding.default_external = Encoding::UTF_8
 
 begin
   # Standard libs
+  require 'readline'
   require 'bundler/setup' unless kali_linux?
   require 'getoptlong'
   require 'optparse' # Will replace getoptlong
@@ -23,7 +24,6 @@ begin
   require 'xmlrpc/client'
   require 'digest/md5'
   require 'digest/sha1'
-  require 'readline'
   require 'base64'
   require 'rbconfig'
   require 'pp'


### PR DESCRIPTION
`'require readline'` before `require 'bundler/setup'` fixes 'gem install readline' issues

```
dctabuyz@dev:~/source/wpscan$ echo 'print (require "bundler/setup"), "\n"; print (require "readline"), "\n"' | ruby                                                     
true
-:1:in `require': cannot load such file -- readline (LoadError)
        from -:1:in `<main>'
```

```
dctabuyz@dev:~/source/wpscan$ echo 'print (require "readline"), "\n"; print (require "bundler/setup"), "\n"' | ruby
true
true
```