### PR TITLE
Fix logic error in parsing command line args

### DIFF
--- a/wpscan.rb
+++ b/wpscan.rb
@@ -371,7 +371,7 @@ def main
     end
 
     # If we haven't been supplied a username/usernames list, enumerate them...
-    if !wpscan_options.username && !wpscan_options.usernames && wpscan_options.wordlist || wpscan_options.enumerate_usernames
+    if !wpscan_options.username && !wpscan_options.usernames && wpscan_options.wordlist
       puts
       puts info('Enumerating usernames ...')
 


### PR DESCRIPTION
This is a simple fix to an annoying logic error that occurs when parsing command line arguments for a brute force attack. 

## The Problem
When a user supplies the `--wordlist` option along with the `--username <target>` and `--enumerate u`, instead of only brute forcing the target username and enumerating the rest, wpscan will bruteforce all of them in ascending order.

## Example

Let's say we run the following:

`wpscan -u "example.com" --enumerate u --wordlist ../wordlists/passwords/top100000.lst --username dingo`

Our intention is to enumerate the users and brute force attack a single user name `dingo`

```
[+] Identified the following 3 user/s:
    +----+--------------+------+
    | Id | Login        | Name |
    +----+--------------+------+
    | 1  | admin        |      |
    | 2  | bob          |      |
    | 3  | dingo        |      |
    +----+--------------+------+
```

Now, instead of attacking the user supplied in the `--username` argument, wpscan just attacks everyone:

```
[+] Starting the password brute forcer
Brute Forcing 'admin' Time: 00:00:04 <=                    > (120 / 100001)  0.11%  ETA: 01:06:17
```

It's a small bug but it can be a little inconvenient at times, so I think it's worth fixing.

Thank you for your consideration 😸 
Peter