### PR TITLE
Fix logic error that arose from fixing a logic error

### DIFF
--- a/wpscan.rb
+++ b/wpscan.rb
@@ -370,8 +370,9 @@ def main
       end
     end
 
-    # If we haven't been supplied a username/usernames list, enumerate them...
-    if !wpscan_options.username && !wpscan_options.usernames && wpscan_options.wordlist || wpscan_options.enumerate_usernames
+    # If we haven't been supplied a username/usernames list but a wordlist is provided, enumerate users...
+    # If previous condition isn't true, enumerate users
+    if (!wpscan_options.username && !wpscan_options.usernames && wpscan_options.wordlist) || wpscan_options.enumerate_usernames
       puts
       puts info('Enumerating usernames ...')
 
@@ -401,8 +402,10 @@ def main
            puts warning("Default first WordPress username 'admin' is still used")
         end
       end
+    end
 
-    else
+    # If user provides username / username list, use that for brute forcing
+    if wpscan_options.username || wpscan_options.usernames
       wp_users = WpUsers.new
 
       if wpscan_options.usernames


### PR DESCRIPTION
This is a fix for my previously failed logic error fix. See here for details: https://github.com/wpscanteam/wpscan/pull/1052

This time, I've thoroughly tested my solution and it will _not_ throw any errors. That's a guarantee. I've certainly learned my lesson about thoroughly testing code, even after a small change.