### PR TITLE
Preciser reporting in bruteforcing password with bad response

### DIFF
--- a/lib/common/models/wp_user/brute_forcable.rb
+++ b/lib/common/models/wp_user/brute_forcable.rb
@@ -118,7 +118,7 @@ class WpUser < WpItem
       elsif response.code.to_s =~ /^50/
         progression = critical('ERROR: Server error, try reducing the number of threads or use the --throttle option.')
       else
-        progression = critical("ERROR: We received an unknown response for #{password}...")
+        progression = critical("ERROR: We received an unknown response for login: #{login} and password: #{password}")
         verbose     = critical("  Code: #{response.code}\n    Body: #{response.body}\n")
       end
 


### PR DESCRIPTION
When bruteforcing for multiple logins and passwords the bad response code reported
might indicate a match! But the reporting for it is not clear enough.
For example "Unkown response for admin" might mean a user name admin and some password
or a password 'admin' for some user.

This commit makes in unambiguous reporting a bad response, and naming which login and
which password caused it.