### PR TITLE
allows wordlist to take command

### DIFF
--- a/lib/common/models/wp_user/brute_forcable.rb
+++ b/lib/common/models/wp_user/brute_forcable.rb
@@ -28,9 +28,19 @@ class WpUser < WpItem
       queue_count  = 0
       found        = false
 
-      create_progress_bar(count_file_lines(wordlist)+1, options)
+      if File.file?(wordlist)
+        wordlist = File.readlines(wordlist)
+      else
+        command = wordlist
+        wordlist = []
+        IO.popen(command).each do |line|
+          wordlist << line.chomp
+        end
+      end
 
-      File.open(wordlist).each do |password|
+      create_progress_bar(wordlist.length+1, options)
+
+      wordlist.each do |password|
         password.chomp!
 
         # A successfull login will redirect us to the redirect_to parameter

--- a/lib/wpscan/wpscan_options.rb
+++ b/lib/wpscan/wpscan_options.rb
@@ -75,10 +75,10 @@ class WpscanOptions
   end
 
   def wordlist=(wordlist)
-    if File.exists?(wordlist)
+    if File.exists?(wordlist) || system("#{wordlist.partition(" ").first}")
       @wordlist = wordlist
     else
-      raise "The file #{wordlist} does not exist"
+      raise "The file #{wordlist} does not exist or is not a command"
     end
   end
 


### PR DESCRIPTION
This is my first time writing anything ruby, so please let me know if this is not the ruby way of doing things and tell me to go to hell. I figured the best use case for this would be providing a crunch command like so:

`wpscan.rb --url <target> --username <user> --wordlist "crunch 10 13 -f charset.lst hex-lower"`

edit: I initially tried to add the feature so that you could do `crunch 10 13 ... | wpscan.rb ...`, but it was only reading the first line. Maybe there's a ruby way of working around that, and if so let me know, but I just implemented the feature this way instead.