### PR TITLE
Don't use colour codes when stdout is redirected

### DIFF
--- a/lib/common/common_helper.rb
+++ b/lib/common/common_helper.rb
@@ -103,7 +103,7 @@ end
 
 # Define colors
 def colorize(text, color_code)
-  if $COLORSWITCH
+  if $COLORSWITCH or not $stdout.isatty
     "#{text}"
   else
     "\e[#{color_code}m#{text}\e[0m"


### PR DESCRIPTION
When output is redirected (either to a file or piped to another program), the colour codes are normally a pain and have to be filtered out (as per the instructions on the wiki).

We can easily detect if stdout is a tty, and just suppress the colour codes if it's not.