### PR TITLE
Added 'Search-Replace-DB' from Interconnect IT to the list of paths to l…

### DIFF
--- a/lib/wpscan/wp_target/wp_config_backup.rb
+++ b/lib/wpscan/wp_target/wp_config_backup.rb
@@ -42,7 +42,7 @@ class WpTarget < WebSite
       %w{
         wp-config.php~ #wp-config.php# wp-config.php.save .wp-config.php.swp wp-config.php.swp wp-config.php.swo
         wp-config.php_bak wp-config.bak wp-config.php.bak wp-config.save wp-config.old wp-config.php.old
-        wp-config.php.orig wp-config.orig wp-config.php.original wp-config.original wp-config.txt
+        wp-config.php.orig wp-config.orig wp-config.php.original wp-config.original wp-config.txt Search-Replace-DB
       } # thanks to Feross.org for these
     end
 


### PR DESCRIPTION
Hello!

This PR adds an extra line in to list of paths to look for exposed config files in.
The line is not a config file itself, but is is the path to a folder called "Search-Replace-DB".

[Search-Replace-DB](https://github.com/interconnectit/Search-Replace-DB) is a popular migration script for WordPress sites. The issue with this is that people tend to keep this script on the server, not cleaning properly after a migration. The even bigger issue is that this script reads the DB credentials from the wp-config.php-file if it is found either in the parent or the second parent folder above the Search-Replace-DB-script.

I think it would be useful for WPScan to look for this. Do you guys agree?