### PR TITLE
Stop trying to execute when it shouldn't

### DIFF
--- a/wpscan.rb
+++ b/wpscan.rb
@@ -524,10 +524,13 @@ def main
     end
     exit(1)
   ensure
-    # Ensure a clean abort of Hydra
-    # See https://github.com/wpscanteam/wpscan/issues/461#issuecomment-42735615
-    Browser.instance.hydra.abort
-    Browser.instance.hydra.run
+    # Make sure there was an argument
+    if ARGV.length != 0
+      # Ensure a clean abort of Hydra
+      # See https://github.com/wpscanteam/wpscan/issues/461#issuecomment-42735615
+      Browser.instance.hydra.abort
+      Browser.instance.hydra.run
+    end
   end
 end
 


### PR DESCRIPTION
## Before

```
g0tmi1k@kali-dev:~$ wpscan 
_______________________________________________________________
        __          _______   _____                  
        \ \        / /  __ \ / ____|                 
         \ \  /\  / /| |__) | (___   ___  __ _ _ __ ®
          \ \/  \/ / |  ___/ \___ \ / __|/ _` | '_ \ 
           \  /\  /  | |     ____) | (__| (_| | | | |
            \/  \/   |_|    |_____/ \___|\__,_|_| |_|

        WordPress Security Scanner by the WPScan Team 
                       Version 2.9.3
          Sponsored by Sucuri - https://sucuri.net
   @_WPScan_, @ethicalhack3r, @erwan_lr, pvdl, @_FireFart_
_______________________________________________________________


Examples :

...SNIP...

See README for further information.


[!] No argument supplied
/usr/lib/ruby/2.3.0/fileutils.rb:254:in `mkdir': Permission denied @ dir_s_mkdir - /usr/share/wpscan/cache/browser (Errno::EACCES)
  from /usr/lib/ruby/2.3.0/fileutils.rb:254:in `fu_mkdir'
  from /usr/lib/ruby/2.3.0/fileutils.rb:228:in `block (2 levels) in mkdir_p'
  from /usr/lib/ruby/2.3.0/fileutils.rb:226:in `reverse_each'
  from /usr/lib/ruby/2.3.0/fileutils.rb:226:in `block in mkdir_p'
  from /usr/lib/ruby/2.3.0/fileutils.rb:211:in `each'
  from /usr/lib/ruby/2.3.0/fileutils.rb:211:in `mkdir_p'
  from /usr/share/wpscan/lib/common/cache_file_store.rb:27:in `initialize'
  from /usr/share/wpscan/lib/common/browser.rb:51:in `new'
  from /usr/share/wpscan/lib/common/browser.rb:51:in `initialize'
  from /usr/share/wpscan/lib/common/browser.rb:64:in `new'
  from /usr/share/wpscan/lib/common/browser.rb:64:in `instance'
  from ./wpscan.rb:530:in `ensure in main'
  from ./wpscan.rb:531:in `main'
  from ./wpscan.rb:535:in `<main>'
g0tmi1k@kali-dev:~$ 
```

- - - 


## After 

```
g0tmi1k@kali-dev:~$ wpscan 
_______________________________________________________________
        __          _______   _____                  
        \ \        / /  __ \ / ____|                 
         \ \  /\  / /| |__) | (___   ___  __ _ _ __ ®
          \ \/  \/ / |  ___/ \___ \ / __|/ _` | '_ \ 
           \  /\  /  | |     ____) | (__| (_| | | | |
            \/  \/   |_|    |_____/ \___|\__,_|_| |_|

        WordPress Security Scanner by the WPScan Team 
                       Version 2.9.3
          Sponsored by Sucuri - https://sucuri.net
   @_WPScan_, @ethicalhack3r, @erwan_lr, pvdl, @_FireFart_
_______________________________________________________________


Examples :

...SNIP...

See README for further information.


[!] No argument supplied
g0tmi1k@kali-dev:~$
```