### PR TITLE
Fixing error on missformated rss

### DIFF
--- a/lib/wpscan/wp_target/wp_rss.rb
+++ b/lib/wpscan/wp_target/wp_rss.rb
@@ -36,8 +36,13 @@ class WpTarget < WebSite
       # If there is nothing there, return false
       return false if data.empty?
 
-      # Read in RSS/XML
-      xml = Nokogiri::XML(data)
+      begin
+        # Read in RSS/XML
+        xml = Nokogiri::XML(data)
+      rescue
+        puts critical("Missformed XML")
+        return false
+      end
 
       begin
         # Look for <dc:creator> item


### PR DESCRIPTION
When there's a link saying a file is a rss but its actually not nokogiri gives an exception. Small patch to catch it an return false. No regression spec included :( 