### PR TITLE
Use LABEL and Make use of multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,8 @@ RUN echo "gem: --no-ri --no-rdoc" > /etc/gemrc
 COPY . /wpscan
 RUN chown -R wpscan:wpscan /wpscan
 
-# runtime dependencies
-RUN apk add --no-cache libcurl procps sqlite-libs && \
-  # build dependencies
-  apk add --no-cache --virtual build-deps git libcurl ruby-dev libffi-dev make gcc musl-dev zlib-dev procps sqlite-dev && \
+# build dependencies
+RUN apk add --no-cache --virtual build-deps git libcurl ruby-dev libffi-dev make gcc musl-dev zlib-dev procps sqlite-dev && \
   bundle install --system --gemfile=/wpscan/Gemfile $BUNDLER_ARGS && \
   apk del --no-cache build-deps
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,8 @@ COPY . /wpscan
 RUN chown -R wpscan:wpscan /wpscan
 
 # build dependencies
-RUN apk add --no-cache --virtual build-deps git libcurl ruby-dev libffi-dev make gcc musl-dev zlib-dev procps sqlite-dev && \
-  bundle install --system --gemfile=/wpscan/Gemfile $BUNDLER_ARGS && \
-  apk del --no-cache build-deps
+RUN apk add --no-cache git libcurl ruby-dev libffi-dev make gcc musl-dev zlib-dev procps sqlite-dev && \
+  bundle install --system --gemfile=/wpscan/Gemfile $BUNDLER_ARGS
 
 WORKDIR /wpscan
 RUN rake install --trace

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /wpscan
 RUN rake install --trace
 
 FROM ruby:2.5-alpine
-LABEL maintainer="WPScan Team <team@wpscan.org>, Mostafa Hussein <mostafa.hussein91@gmail.com>"
+LABEL maintainer="WPScan Team <team@wpscan.org>"
 
 RUN adduser -h /wpscan -g WPScan -D wpscan
 


### PR DESCRIPTION
Maintainer keyword should be replaced with LABEL, and Also using multistage build decreases the image size from 139MB to 117MB

Signed-off-by: Mostafa Hussein <mostafa.hussein91@gmail.com>

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor is offering the WPScan company (company number 	83421476900012), which is registered in France, the unlimited, non-exclusive right to reuse, modify, and relicense the code.