### PR TITLE
Fixed pattern matching on target.wordpress_hosted

### DIFF
--- a/lib/wpscan/target/platform/wordpress.rb
+++ b/lib/wpscan/target/platform/wordpress.rb
@@ -41,7 +41,7 @@ module WPScan
         end
 
         def wordpress_hosted?
-          uri.host =~ /wordpress.com$/i ? true : false
+          uri.host =~ /\.wordpress\.com$/i ? true : false
         end
 
         # @param [ String ] username

--- a/spec/shared_examples/target/platform/wordpress.rb
+++ b/spec/shared_examples/target/platform/wordpress.rb
@@ -37,5 +37,11 @@ shared_examples WPScan::Target::Platform::WordPress do
 
       its(:wordpress_hosted?) { should be true }
     end
+
+    context 'when the target host doesn\'t matches' do
+      let(:url) { 'http://ex-wordpress.com' }
+
+      its(:wordpress_hosted?) { should be false }
+    end
   end
 end


### PR DESCRIPTION
The pattern-matching in the wordpress_hosted attribute was too open, 
for instance the website https://mytest-wordpress.com would be recognized as a wordpress-hosted website, which it isn't.

In addition, the dots were not escaped in the regex, which means https://mytest-wordpress-com would match as well (if it was a correct fqdn).

The regex has been replaced by /\.wordpress\.com$/i  .

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor is offering the WPScan company (company number 	83421476900012), which is registered in France, the unlimited, non-exclusive right to reuse, modify, and relicense the code.