### PR TITLE
Fix links to API signup page

### DIFF
--- a/app/views/cli/vuln_api/status.erb
+++ b/app/views/cli/vuln_api/status.erb
@@ -9,5 +9,5 @@
 <% end -%>
 <% else -%>
 <%= warning_icon %> No WPVulnDB API Token given, as a result vulnerability data has not been output.
-<%= warning_icon %> You can get a free API token with 50 daily requests by registering at https://wpvulndb.com/users/sign_up.
+<%= warning_icon %> You can get a free API token with 50 daily requests by registering at https://wpvulndb.com/users/sign_up .
 <% end -%>

--- a/app/views/json/vuln_api/status.erb
+++ b/app/views/json/vuln_api/status.erb
@@ -8,6 +8,6 @@
 "requests_remaining": <%= @status['requests_remaining'].to_json %>
 <% end -%>
 <% else -%>
-"error": "No WPVulnDB API Token given, as a result vulnerability data has not been output.\nYou can get a free API token with 50 daily requests by registering at https://wpvulndb.com/users/sign_up."
+"error": "No WPVulnDB API Token given, as a result vulnerability data has not been output.\nYou can get a free API token with 50 daily requests by registering at https://wpvulndb.com/users/sign_up ."
 <% end -%>
 },

--- a/spec/output/vuln_api/no_token.cli_no_colour
+++ b/spec/output/vuln_api/no_token.cli_no_colour
@@ -1,2 +1,2 @@
 [!] No WPVulnDB API Token given, as a result vulnerability data has not been output.
-[!] You can get a free API token with 50 daily requests by registering at https://wpvulndb.com/users/sign_up.
+[!] You can get a free API token with 50 daily requests by registering at https://wpvulndb.com/users/sign_up .

--- a/spec/output/vuln_api/no_token.json
+++ b/spec/output/vuln_api/no_token.json
@@ -1,5 +1,5 @@
 {
   "vuln_api": {
-    "error": "No WPVulnDB API Token given, as a result vulnerability data has not been output.\nYou can get a free API token with 50 daily requests by registering at https://wpvulndb.com/users/sign_up."
+    "error": "No WPVulnDB API Token given, as a result vulnerability data has not been output.\nYou can get a free API token with 50 daily requests by registering at https://wpvulndb.com/users/sign_up ."
   }
 }


### PR DESCRIPTION
If the user does not input the WPVulnDB API key, they'll get an error like:
```
"error": "No WPVulnDB API Token given, as a result vulnerability data has not been output.\nYou can get a free API token with 50 daily requests by registering at https://wpvulndb.com/users/sign_up."
```
Specifically, the link of https://wpvulndb.com/users/sign_up. ends up 404-ing because many terminals include the "." in the URL (happened to me). Thus, this PR simply adds a space to fix this issue so that the "." is not included in the URL and a user is able to click the registration link in their terminal.


## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor is offering the WPScan company (company number 	83421476900012), which is registered in France, the unlimited, non-exclusive right to reuse, modify, and relicense the code.