### PR TITLE
updater: don't change db if --no-update is passed

### DIFF
--- a/lib/wpscan/db/updater.rb
+++ b/lib/wpscan/db/updater.rb
@@ -24,6 +24,7 @@ module WPScan
 
         FileUtils.mkdir_p(repo_directory.to_s) unless Dir.exist?(repo_directory.to_s)
 
+        return if ParsedCli.update == "false"
         raise "#{repo_directory} is not writable" unless repo_directory.writable?
 
         delete_old_files


### PR DESCRIPTION
If `--no-update` is explicitly passed on the command line, don't attempt to modify the wpscan database.

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor is offering the WPScan company (company number 	83421476900012), which is registered in France, the unlimited, non-exclusive right to reuse, modify, and relicense the code.