### PR TITLE
Update regex for WP Duplicator plugin installer-log

### DIFF
--- a/app/finders/interesting_findings/duplicator_installer_log.rb
+++ b/app/finders/interesting_findings/duplicator_installer_log.rb
@@ -9,7 +9,7 @@ module WPScan
         def aggressive(_opts = {})
           path = 'installer-log.txt'
 
-          return unless /DUPLICATOR INSTALL-LOG/.match?(target.head_and_get(path).body)
+          return unless /DUPLICATOR(?:-(PRO|LITE):)? INSTALL-LOG/i.match?(target.head_and_get(path).body)
 
           Model::DuplicatorInstallerLog.new(target.url(path), confidence: 100, found_by: DIRECT_ACCESS)
         end

--- a/app/finders/interesting_findings/duplicator_installer_log.rb
+++ b/app/finders/interesting_findings/duplicator_installer_log.rb
@@ -9,7 +9,7 @@ module WPScan
         def aggressive(_opts = {})
           path = 'installer-log.txt'
 
-          return unless /DUPLICATOR(?:-(PRO|LITE):)? INSTALL-LOG/i.match?(target.head_and_get(path).body)
+          return unless /DUPLICATOR(-|\s)?(PRO|LITE)?:? INSTALL-LOG/i.match?(target.head_and_get(path).body)
 
           Model::DuplicatorInstallerLog.new(target.url(path), confidence: 100, found_by: DIRECT_ACCESS)
         end


### PR DESCRIPTION
## Description

Looks like this regex pattern is outdated, since Duplicator plugin released its Lite and Pro versions.

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor is offering the WPScan company (company number 	83421476900012), which is registered in France, the unlimited, non-exclusive right to reuse, modify, and relicense the code.