### PR TITLE
fixed typo in link (wpscam.com)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The DB is located at ~/.wpscan/db
 
 ## Vulnerability Database
 
-The WPScan CLI tool uses the [WPScan API](https://wpscan.com/api) to retrieve WordPress vulnerability data in real time. For WPScan to retrieve the vulnerability data an API token must be supplied via the `--api-token` option, or via a configuration file, as discussed below. An API token can be obtained by registering an account on [WPScan](https://wpscam.com/register). Up to 50 API requests per day are given free of charge to registered users. Once the 50 API requests are exhausted, WPScan will continue to work as normal but without any vulnerability data. Users can upgrade to paid API usage to increase their API limits within their user profile on [WPScan](https://wpscan.com/).
+The WPScan CLI tool uses the [WPScan API](https://wpscan.com/api) to retrieve WordPress vulnerability data in real time. For WPScan to retrieve the vulnerability data an API token must be supplied via the `--api-token` option, or via a configuration file, as discussed below. An API token can be obtained by registering an account on [WPScan](https://wpscan.com/register). Up to 50 API requests per day are given free of charge to registered users. Once the 50 API requests are exhausted, WPScan will continue to work as normal but without any vulnerability data. Users can upgrade to paid API usage to increase their API limits within their user profile on [WPScan](https://wpscan.com/).
 
 ## Load CLI options from file/s
 


### PR DESCRIPTION
The latest version of the Readme linked to wpscam.com in a hyperlink. This PR fixes that typo.

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor is offering the WPScan company (company number 	83421476900012), which is registered in France, the unlimited, non-exclusive right to reuse, modify, and relicense the code.