### PR TITLE
Update Ethon dep

### DIFF
--- a/wpscan.gemspec
+++ b/wpscan.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_paths         = ['lib']
 
   s.add_dependency 'cms_scanner', '~> 0.13.3'
-  s.add_dependency 'ethon', '< 0.13.0' # See https://github.com/typhoeus/ethon/issues/185
+  s.add_dependency 'ethon', '~> 0.14.0' # See https://github.com/typhoeus/ethon/issues/185, remove that when new version of CMSScanner used
 
   s.add_development_dependency 'bundler',             '>= 1.6'
   s.add_development_dependency 'memory_profiler',     '~> 1.0.0'


### PR DESCRIPTION
## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor is offering the WPScan company (company number 	83421476900012), which is registered in France, the unlimited, non-exclusive right to reuse, modify, and relicense the code.