### PR TITLE
Added gcc + make to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@
   - The < 7.72 could result in `Stream error in the HTTP/2 framing layer` in some cases
 - RubyGems      - Recommended: latest
 - Nokogiri might require packages to be installed via your package manager depending on your OS, see https://nokogiri.org/tutorials/installing_nokogiri.html
+- gcc           - Recommended: latest
+- make          - Recommended: latest
 
 ### In a Pentesting distribution
 


### PR DESCRIPTION
Updated readme to fix a failed gem installation resulting in a cryptic

> checking for ffi.h... *** extconf.rb failed ***

Error

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor is offering the WPScan company (company number 	83421476900012), which is registered in France, the unlimited, non-exclusive right to reuse, modify, and relicense the code.