### PR TITLE
Fixed using proper proxy auth credentials when updating the database and talking to the WPScan API.

### DIFF
--- a/lib/wpscan/db/updater.rb
+++ b/lib/wpscan/db/updater.rb
@@ -73,7 +73,7 @@ module WPScan
       # @return [ Hash ] The params for Typhoeus::Request
       # @note Those params can't be overriden by CLI options
       def request_params
-        @request_params ||= Browser.instance.default_connect_request_params.merge(
+        @request_params ||= Browser.instance.default_request_params.merge(
           timeout: 600,
           connecttimeout: 300,
           accept_encoding: 'gzip, deflate',

--- a/lib/wpscan/db/vuln_api.rb
+++ b/lib/wpscan/db/vuln_api.rb
@@ -70,7 +70,7 @@ module WPScan
       # @return [ Hash ]
       # @note Those params can not be overriden by CLI options
       def self.default_request_params
-        @default_request_params ||= Browser.instance.default_connect_request_params.merge(
+        @default_request_params ||= Browser.instance.default_request_params.merge(
           headers: {
             'User-Agent' => Browser.instance.default_user_agent,
             'Authorization' => "Token token=#{token}"


### PR DESCRIPTION
The TL;DR of this is that this was calling [a wrong function](https://github.com/wpscanteam/CMSScanner/blob/master/lib/cms_scanner/browser.rb#L42) where the `proxyuserpwd` parameter [does not get added](https://github.com/wpscanteam/CMSScanner/blob/master/lib/cms_scanner/browser.rb#L79) in the CMSScanner gem.

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor is offering the WPScan company (company number 	83421476900012), which is registered in France, the unlimited, non-exclusive right to reuse, modify, and relicense the code.