### PR TITLE
Fixes Gem Push action

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Ruby 2.6
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
 
     #- name: Publish to GPR
     #  run: |


### PR DESCRIPTION
According to https://github.com/ruby/setup-ruby#supported-version-syntax, using `2.6` instead of `2.6.x` will install the latest in the 2.6 branch 