### PR TITLE
Fix case where a theme slug is all non-latin characters

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -92,7 +92,7 @@ module WPScan
           tags: 'Tags',
           text_domain: 'Text Domain'
         }.each do |attribute, tag|
-          instance_variable_set(:"@#{attribute}", parse_style_tag(style_body, tag))
+          instance_variable_set(:"@#{attribute}", parse_style_tag(style_body, tag)&.force_encoding('UTF-8'))
         end
       end
 

--- a/lib/wpscan/helper.rb
+++ b/lib/wpscan/helper.rb
@@ -16,5 +16,8 @@ def classify_slug(slug)
   classified = slug.to_s.gsub(/[^a-z\d\-]/i, '-').gsub(/-{1,}/, '_').camelize.to_s
   classified = "D_#{classified}" if /\d/.match?(classified[0])
 
+  # Special case for slugs with all non-latin characters.
+  classified = "HexSlug_#{slug.bytes.map { |i| i.to_s(16) }.join}" if classified.empty?
+
   classified.to_sym
 end

--- a/spec/lib/helper_spec.rb
+++ b/spec/lib/helper_spec.rb
@@ -7,7 +7,8 @@ describe '#classify_slug' do
     '12-slug' => :D_12Slug,
     'slug.s' => :SlugS,
     'slug yolo $' => :SlugYolo,
-    'slug $ ab.cd/12' => :SlugAbCd12
+    'slug $ ab.cd/12' => :SlugAbCd12,
+    'カスタムテーマ' => :HexSlug_e382abe382b9e382bfe383a0e38386e383bce3839e
   }.each do |slug, expected_symbol|
     context "when #{slug}" do
       it "returns #{expected_symbol}" do


### PR DESCRIPTION
Fixes #1771

Adds a special case when it creates a class for the slug. If it has all non-latin characters, it would previously return an empty string and fail. Now it creates a slug using a hex representation of the characters if the string would otherwise be empty.

Also needed to force a UTF-8 encoding when parsing the theme's style.css to get the information. This was a fun bug to track down... 🙃 