### PR TITLE
Replace RVM with rbenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ## Prerequisites
 
-- (Optional but highly recommended: [RVM](https://rvm.io/rvm/install))
+- (Optional but highly recommended: [rbenv](https://github.com/rbenv/rbenv))
 - Ruby >= 2.7 - Recommended: latest
 - Curl >= 7.72  - Recommended: latest
   - The 7.29 has a segfault


### PR DESCRIPTION
rbenv seems like a more sane approach to handling ruby environments: https://www.reddit.com/r/rails/comments/f009mb/there_are_two_ruby_version_manager_rvm_vs_rbenv/?sort=new

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor is offering the WPScan company (company number 	83421476900012), which is registered in France, the unlimited, non-exclusive right to reuse, modify, and relicense the code.