### PR TITLE
Populate valid versions from metadata, too

### DIFF
--- a/app/models/wp_version.rb
+++ b/app/models/wp_version.rb
@@ -25,6 +25,10 @@ module WPScan
 
         @all_numbers = []
 
+        DB::Version.metadata.each_key do |ver|
+          @all_numbers << ver
+        end
+
         DB::Fingerprints.wp_fingerprints.each_value do |fp|
           @all_numbers << fp.values
         end


### PR DESCRIPTION
Currently, WPScan populates its list of valid WordPress versions
from a list of fingerprinted WordPress files.

However, this file is not always up-to-date, causing version
detection to fail as WPScan thinks its not a valid version
and raises a InvalidWordPressVersion exception.

Since a lot of the version information is also pulled from
metadata.json anyway, also include this file for the initial
version detection, instead of just relying on the list of
fingerprinted files.

Fixes #1849 

## Discussion Question
I don't know why exactly the versions were pulled from the fingerprint files, anyway.
Maybe it makes sense to remove it completely?
Since I did not know, I went for the defensive approach and just determining the version based on both of them.

But I wonder why if there is a specific reason why it was not pulled from the metadata before, or why it was based on the fingerprints only.

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor is offering the WPScan company (company number 	83421476900012), which is registered in France, the unlimited, non-exclusive right to reuse, modify, and relicense the code.