### PR TITLE
Ensure update db now prompt is printed

### DIFF
--- a/app/controllers/core.rb
+++ b/app/controllers/core.rb
@@ -38,13 +38,11 @@ module WPScan
 
         output('@notice', msg: 'It seems like you have not updated the database for some time.')
         print '[?] Do you want to update now? [Y]es [N]o, default: [N]'
-        # $stdout.flush
+        $stdout.flush
 
-        # response = $stdin.gets.to_s.strip
-        #
-        # !!/^y/i.match?(response)
+        response = $stdin.gets.to_s.strip
 
-        /^y/i.match?(Readline.readline)
+        !!/^y/i.match?(response)
       end
 
       def update_db

--- a/app/controllers/core.rb
+++ b/app/controllers/core.rb
@@ -37,7 +37,10 @@ module WPScan
         return false unless user_interaction? && local_db.outdated?
 
         output('@notice', msg: 'It seems like you have not updated the database for some time.')
-        response = Readline.readline('[?] Do you want to update now? [Y]es [N]o, default: [N] ', true)
+        print '[?] Do you want to update now? [Y]es [N]o, default: [N]'
+        $stdout.flush
+
+        response = $stdin.gets.to_s.strip
 
         !!/^y/i.match?(response)
       end

--- a/app/controllers/core.rb
+++ b/app/controllers/core.rb
@@ -37,9 +37,9 @@ module WPScan
         return false unless user_interaction? && local_db.outdated?
 
         output('@notice', msg: 'It seems like you have not updated the database for some time.')
-        print '[?] Do you want to update now? [Y]es [N]o, default: [N]'
+        response = Readline.readline('[?] Do you want to update now? [Y]es [N]o, default: [N] ', true)
 
-        /^y/i.match?(Readline.readline)
+        !!/^y/i.match?(response)
       end
 
       def update_db

--- a/app/controllers/core.rb
+++ b/app/controllers/core.rb
@@ -38,11 +38,13 @@ module WPScan
 
         output('@notice', msg: 'It seems like you have not updated the database for some time.')
         print '[?] Do you want to update now? [Y]es [N]o, default: [N]'
-        $stdout.flush
+        # $stdout.flush
 
-        response = $stdin.gets.to_s.strip
+        # response = $stdin.gets.to_s.strip
+        #
+        # !!/^y/i.match?(response)
 
-        !!/^y/i.match?(response)
+        /^y/i.match?(Readline.readline)
       end
 
       def update_db

--- a/spec/app/controllers/core_spec.rb
+++ b/spec/app/controllers/core_spec.rb
@@ -106,26 +106,24 @@ describe WPScan::Controller::Core do
 
         context 'when the db is outdated' do
           before do
-            # allow(core).to receive(:user_interaction?).and_return(true)
+            allow(core).to receive(:user_interaction?).and_return(true)
             expect(core.local_db).to receive(:outdated?).ordered.and_return(true)
             expect(core.formatter).to receive(:output).with('@notice', hash_including(:msg), 'core').ordered
             expect($stdout).to receive(:write).ordered # for the print()
           end
 
           context 'when a positive answer' do
-            before { expect(Readline).to receive(:readline).and_return('Yes').ordered }
-            # before do
-            #   allow($stdin).to receive(:gets).and_return("Yes\n")
-            # end
+            before do
+              allow($stdin).to receive(:gets).and_return("Yes\n")
+            end
 
             its(:update_db_required?) { should eql true }
           end
 
           context 'when a negative answer' do
-            before { expect(Readline).to receive(:readline).and_return('no').ordered }
-            # before do
-            #   allow($stdin).to receive(:gets).and_return("No\n")
-            # end
+            before do
+              allow($stdin).to receive(:gets).and_return("No\n")
+            end
 
             its(:update_db_required?) { should eql false }
           end

--- a/spec/app/controllers/core_spec.rb
+++ b/spec/app/controllers/core_spec.rb
@@ -106,19 +106,25 @@ describe WPScan::Controller::Core do
 
         context 'when the db is outdated' do
           before do
+            allow(core).to receive(:user_interaction?).and_return(true)
             expect(core.local_db).to receive(:outdated?).ordered.and_return(true)
             expect(core.formatter).to receive(:output).with('@notice', hash_including(:msg), 'core').ordered
-            expect($stdout).to receive(:write).ordered # for the print()
           end
 
           context 'when a positive answer' do
-            before { expect(Readline).to receive(:readline).and_return('Yes').ordered }
+            before do
+              expect(Readline).to receive(:readline).with('[?] Do you want to update now? [Y]es [N]o, default: [N] ',
+                                                          true).and_return('Yes')
+            end
 
             its(:update_db_required?) { should eql true }
           end
 
           context 'when a negative answer' do
-            before { expect(Readline).to receive(:readline).and_return('no').ordered }
+            before do
+              expect(Readline).to receive(:readline).with('[?] Do you want to update now? [Y]es [N]o, default: [N] ',
+                                                          true).and_return('No')
+            end
 
             its(:update_db_required?) { should eql false }
           end

--- a/spec/app/controllers/core_spec.rb
+++ b/spec/app/controllers/core_spec.rb
@@ -106,6 +106,7 @@ describe WPScan::Controller::Core do
 
         context 'when the db is outdated' do
           before do
+            # allow(core).to receive(:user_interaction?).and_return(true)
             expect(core.local_db).to receive(:outdated?).ordered.and_return(true)
             expect(core.formatter).to receive(:output).with('@notice', hash_including(:msg), 'core').ordered
             expect($stdout).to receive(:write).ordered # for the print()
@@ -113,12 +114,18 @@ describe WPScan::Controller::Core do
 
           context 'when a positive answer' do
             before { expect(Readline).to receive(:readline).and_return('Yes').ordered }
+            # before do
+            #   allow($stdin).to receive(:gets).and_return("Yes\n")
+            # end
 
             its(:update_db_required?) { should eql true }
           end
 
           context 'when a negative answer' do
             before { expect(Readline).to receive(:readline).and_return('no').ordered }
+            # before do
+            #   allow($stdin).to receive(:gets).and_return("No\n")
+            # end
 
             its(:update_db_required?) { should eql false }
           end

--- a/spec/app/controllers/core_spec.rb
+++ b/spec/app/controllers/core_spec.rb
@@ -152,12 +152,12 @@ describe WPScan::Controller::Core do
     context 'when --update' do
       before do
         expect(core.formatter).to receive(:output)
-                                    .with('db_update_started', hash_including(verbose: nil), 'core').ordered
+          .with('db_update_started', hash_including(verbose: nil), 'core').ordered
 
         expect_any_instance_of(WPScan::DB::Updater).to receive(:update)
 
         expect(core.formatter).to receive(:output)
-                                    .with('db_update_finished', hash_including(verbose: nil), 'core').ordered
+          .with('db_update_finished', hash_including(verbose: nil), 'core').ordered
       end
 
       context 'when the --url is not supplied' do
@@ -201,8 +201,8 @@ describe WPScan::Controller::Core do
           stub_request(:any, target_url)
 
           expect(core.target).to receive(:homepage_res)
-                                   .at_least(1)
-                                   .and_return(Typhoeus::Response.new(effective_url: redirection, body: ''))
+            .at_least(1)
+            .and_return(Typhoeus::Response.new(effective_url: redirection, body: ''))
         end
 
         context 'to the wp-admin/install.php' do
@@ -210,7 +210,7 @@ describe WPScan::Controller::Core do
 
           it 'calls the formatter with the correct parameters and exit' do
             expect(core.formatter).to receive(:output)
-                                        .with('not_fully_configured', hash_including(url: redirection), 'core').ordered
+              .with('not_fully_configured', hash_including(url: redirection), 'core').ordered
 
             # TODO: Would be cool to be able to test the exit code
             expect { core.before_scan }.to raise_error(SystemExit)

--- a/spec/app/controllers/core_spec.rb
+++ b/spec/app/controllers/core_spec.rb
@@ -106,25 +106,19 @@ describe WPScan::Controller::Core do
 
         context 'when the db is outdated' do
           before do
-            allow(core).to receive(:user_interaction?).and_return(true)
             expect(core.local_db).to receive(:outdated?).ordered.and_return(true)
             expect(core.formatter).to receive(:output).with('@notice', hash_including(:msg), 'core').ordered
+            expect($stdout).to receive(:write).ordered # for the print()
           end
 
           context 'when a positive answer' do
-            before do
-              expect(Readline).to receive(:readline).with('[?] Do you want to update now? [Y]es [N]o, default: [N] ',
-                                                          true).and_return('Yes')
-            end
+            before { expect(Readline).to receive(:readline).and_return('Yes').ordered }
 
             its(:update_db_required?) { should eql true }
           end
 
           context 'when a negative answer' do
-            before do
-              expect(Readline).to receive(:readline).with('[?] Do you want to update now? [Y]es [N]o, default: [N] ',
-                                                          true).and_return('No')
-            end
+            before { expect(Readline).to receive(:readline).and_return('no').ordered }
 
             its(:update_db_required?) { should eql false }
           end
@@ -151,12 +145,12 @@ describe WPScan::Controller::Core do
     context 'when --update' do
       before do
         expect(core.formatter).to receive(:output)
-          .with('db_update_started', hash_including(verbose: nil), 'core').ordered
+                                    .with('db_update_started', hash_including(verbose: nil), 'core').ordered
 
         expect_any_instance_of(WPScan::DB::Updater).to receive(:update)
 
         expect(core.formatter).to receive(:output)
-          .with('db_update_finished', hash_including(verbose: nil), 'core').ordered
+                                    .with('db_update_finished', hash_including(verbose: nil), 'core').ordered
       end
 
       context 'when the --url is not supplied' do
@@ -200,8 +194,8 @@ describe WPScan::Controller::Core do
           stub_request(:any, target_url)
 
           expect(core.target).to receive(:homepage_res)
-            .at_least(1)
-            .and_return(Typhoeus::Response.new(effective_url: redirection, body: ''))
+                                   .at_least(1)
+                                   .and_return(Typhoeus::Response.new(effective_url: redirection, body: ''))
         end
 
         context 'to the wp-admin/install.php' do
@@ -209,7 +203,7 @@ describe WPScan::Controller::Core do
 
           it 'calls the formatter with the correct parameters and exit' do
             expect(core.formatter).to receive(:output)
-              .with('not_fully_configured', hash_including(url: redirection), 'core').ordered
+                                        .with('not_fully_configured', hash_including(url: redirection), 'core').ordered
 
             # TODO: Would be cool to be able to test the exit code
             expect { core.before_scan }.to raise_error(SystemExit)


### PR DESCRIPTION
## Fixes

Issue: https://github.com/wpscanteam/wpscan/issues/1827

As of ruby `3.3.0`, `update_db_required` no longer prints the last prompt. This is apparently due to behavorial changes introduced around `Readline.readline`.

Initially I attempted to maintain the use of `Readline.readline` but adjust it to account for the the changes, however, I noticed the following warning in CI builds:
```
/opt/hostedtoolcache/Ruby/3.4.2/x64/lib/ruby/3.4.0/readline.rb:4: warning: reline was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add reline to your Gemfile or gemspec to silence this warning.
```
Therefore I've proactively opted to circumnavigate these issues with a secondary approach using `$stdin.gets`.

## Testing
- Checkout this branch
- Ensure you a running ruby `3.3.0`
- Comment out all but the last 3 lines of `update_db_required`
- Run `wpscan --update`
- Verify that all expected content is output and respect the provided request
- Revert to version of ruby prior to `3.3.0` (I've confirmed that version `3.2.2` work without issue previously), and ensure the missing prompt is still output running the same command