### PR TITLE
Don't push daily docker images even though nothing changed.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,6 @@
 name: Build Docker Images
 
 on:
-  push:
-    branches:
-      - master
   release:
     types: [published]
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,8 +6,6 @@ on:
       - master
   release:
     types: [published]
-  schedule:
-    - cron: "0 7 * * *"
 
 jobs:
   images:


### PR DESCRIPTION
I also tried to find out why exactly was added, but [the commit adding it](https://github.com/wpscanteam/wpscan/commit/9db97d07301fd90942e3efe59b5737caa51cb1c3) does not really give any context about that, unfortunately.

I have also removed it running on master pushes, I think this was probably a misunderstanding of the "latest" tag, which is supposed to have the latest tagged version in that latest tag, and not always the latest code from master.