### PR TITLE
Running the full test suite including the dynamic finder tests takes roughly an hour on GitHub, we don't really need to do that for each single PR, we can just run all the other tests there, and limit these to master.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,13 @@ jobs:
         bundle exec rubocop
 
     # Runs Specs which are not tagged as slow first to speed up the process in case of failure in those
-    # Then will run the full specs suite (and generate the final coverage report)
+    # The full specs suite (and final coverage report) only runs on pushes to master to keep PRs quick
     - name: rspec
-      run: |
-        bundle exec rspec --tag ~slow
-        bundle exec rspec
+      run: bundle exec rspec --tag ~slow
+
+    - name: rspec (full suite)
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      run: bundle exec rspec
 
     - name: Coveralls
       uses: coverallsapp/github-action@master


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

## Proposed changes

* Only run the full test suite on master, so that checks on the PRs are much quicker and mostly cover everything already anyway.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The tests for the dynamic finders are extensive because we run them for all finders every time.
* This becomes a hindrance when working on PRs, so let's only do that on master, and we can check if everything is green before making a new release.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The CI checks should be much faster on this PR than others ([example of longer running PR](https://github.com/wpscanteam/wpscan/pull/1954))
