### PR TITLE
Updated ruby 3.0 requirements to at least 3.3.

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -11,22 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
-    - name: Set up Ruby 3.0
+    - name: Set up Ruby 4.0
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0'
-
-    #- name: Publish to GPR
-    #  run: |
-    #    mkdir -p $HOME/.gem
-    #    touch $HOME/.gem/credentials
-    #    chmod 0600 $HOME/.gem/credentials
-    #    printf -- "---\n:github: Bearer ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-    #    gem build *.gemspec
-    #    gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
-    #  env:
-    #    GEM_HOST_API_KEY: ${{secrets.GITHUB_TOKEN}}
-    #    OWNER: wpscanteam
+        ruby-version: '4.0'
 
     - name: Publish to RubyGems
       run: |

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ plugins: rubocop-performance
 AllCops:
   NewCops: enable
   SuggestExtensions: false
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.3
   Exclude:
   - '*.gemspec'
   - 'vendor/**/*'

--- a/wpscan.gemspec
+++ b/wpscan.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.name                  = 'wpscan'
   s.version               = WPScan::VERSION
   s.platform              = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 3.0'
+  s.required_ruby_version = '>= 3.3'
   s.authors               = ['WPScanTeam']
   s.email                 = ['contact@wpscan.com']
   s.summary               = 'WPScan - WordPress Vulnerability Scanner'
@@ -21,14 +21,8 @@ Gem::Specification.new do |s|
   s.require_paths         = ['lib']
 
   s.add_dependency 'cms_scanner', '~> 0.15.0'
-
-  # Fixes
-  # - warning: ostruct was loaded from the standard library
-  # - warning: fiddle was loaded from the standard library
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.3')
-    s.add_dependency('ostruct', '~> 0.6')
-    s.add_dependency('fiddle', '~> 1.1')
-  end
+  s.add_dependency('ostruct', '~> 0.6')
+  s.add_dependency('fiddle', '~> 1.1')
 
   s.add_development_dependency 'bundler',             '>= 1.6'
   s.add_development_dependency 'memory_profiler',     '~> 1.0.0'


### PR DESCRIPTION


## Proposed changes

* Set rubocop target version to at least 3.3 (this tells rubocop which ruby syntax features are available on all versions, so it needs to stay on the lowest supported version)
* Update gempush ruby version to 4.0.
* Update gemspec to require least 3.3.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Follow-up to https://github.com/wpscanteam/wpscan/pull/1971 where I missed a few places to adjust.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

CI