### PR TITLE
Update docs for XDG Base Directory support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ WPScan is a WordPress security scanner written in Ruby. It's built on top of the
 **Key characteristics:**
 - Ruby gem with CLI tool
 - Architecture based on Controllers, Finders, and Models (MVC-like pattern)
-- Uses local database (in `~/.wpscan/db`) that syncs with WPScan API
+- Uses local database (in `$XDG_CACHE_HOME/wpscan/db` or `~/.cache/wpscan/db`, or `~/.wpscan/db` for existing installations) that syncs with WPScan API
 - Built on top of CMSScanner framework (parent gem)
 - Supports WordPress-specific security scanning features
 
@@ -67,7 +67,8 @@ wpscan --url https://example.com
 # Update local database
 wpscan --update
 
-# The database is stored in ~/.wpscan/db
+# The database is stored in $XDG_CACHE_HOME/wpscan/db or ~/.cache/wpscan/db (new installations)
+# or ~/.wpscan/db (existing installations)
 ```
 
 ## Architecture
@@ -122,7 +123,7 @@ Domain objects representing WordPress components:
 - `VulnApi` - API client for vulnerability data
 - `DynamicFinders` - Auto-generated finders from database metadata
 - `Fingerprints` - Version detection fingerprints
-- Database stored in `~/.wpscan/db/` by default (overridden in specs to `spec/fixtures/db/`)
+- Database stored in `$XDG_CACHE_HOME/wpscan/db/` or `~/.cache/wpscan/db/` (new installations) or `~/.wpscan/db/` (existing installations) by default (overridden in specs to `spec/fixtures/db/`)
 
 ### Important Patterns
 
@@ -171,7 +172,7 @@ The codebase tracks API requests via `WPScan.api_requests` class variable to mon
 When using `wpscan` from source, run it outside the git repo to avoid load path conflicts.
 
 **Database Location:**
-Tests override `DB_DIR` to `spec/fixtures/db/`. Production uses `~/.wpscan/db`.
+Tests override `DB_DIR` to `spec/fixtures/db/`. Production uses `$XDG_CACHE_HOME/wpscan/db` or `~/.cache/wpscan/db` (new installations) or `~/.wpscan/db` (existing installations).
 
 **Port Normalization:**
 WebMock adapter has custom port normalization for Typhoeus (spec/spec_helper.rb:63-96) to handle default ports.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,18 @@ As a result, when using the ```--enumerate``` option, don't forget to set the ``
 
 For more options, open a terminal and type ```wpscan --help``` (if you built wpscan from the source, you should type the command outside of the git repo)
 
-The DB is located at ~/.wpscan/db
+## Database Location
+
+The database location follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html):
+
+- **New installations**: `~/.cache/wpscan/db` (or `$XDG_CACHE_HOME/wpscan/db` if set)
+- **Existing installations**: `~/.wpscan/db` (legacy path, maintained for backward compatibility)
+
+To migrate an existing installation to the XDG path:
+
+```shell
+mv ~/.wpscan ~/.cache/wpscan
+```
 
 ## Optional: WordPress Vulnerability Database API
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Related to https://github.com/wpscanteam/wpscan/pull/1815

## Proposed changes

* Update README.md and AGENTS.md to document XDG Base Directory Specification support for database location

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

#1815 added XDG support for the database location but the documentation still referenced only the legacy path (`~/.wpscan/db`). This PR updates the documentation to reflect the actual behavior.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Proofread the changes

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor grants Automattic Inc. the unlimited, non-exclusive right to reuse, modify, and relicense the code.

