### PR TITLE
Added --proxy-target-only CLI option that allows to only send requests to the target through the proxy, and send others (data.wpscan.org and WPScan API) without the proxy directly to the internet.

### DIFF
--- a/app/controllers/vuln_api.rb
+++ b/app/controllers/vuln_api.rb
@@ -11,6 +11,12 @@ module WPScan
           OptString.new(
             ['--api-token TOKEN',
              'The WPScan API Token to display vulnerability data, available at https://wpscan.com/profile']
+          ),
+          OptBoolean.new(
+            ['--proxy-target-only',
+             'When used with --proxy, the proxy is only applied to requests made to the target, ' \
+             'not to requests made to the WPScan API or database repository (data.wpscan.org). ' \
+             'Has no effect unless --proxy is also set.']
           )
         ]
       end

--- a/lib/wpscan/db/updater.rb
+++ b/lib/wpscan/db/updater.rb
@@ -73,13 +73,22 @@ module WPScan
       # @return [ Hash ] The params for Typhoeus::Request
       # @note Those params can't be overriden by CLI options
       def request_params
-        @request_params ||= Browser.instance.default_request_params.merge(
-          timeout: 600,
-          connecttimeout: 300,
-          accept_encoding: 'gzip, deflate',
-          cache_ttl: 0,
-          headers: { 'User-Agent' => Browser.instance.default_user_agent }
-        )
+        @request_params ||= begin
+          params = Browser.instance.default_request_params.merge(
+            timeout: 600,
+            connecttimeout: 300,
+            accept_encoding: 'gzip, deflate',
+            cache_ttl: 0,
+            headers: { 'User-Agent' => Browser.instance.default_user_agent }
+          )
+
+          if ParsedCli.proxy_target_only
+            params.delete(:proxy)
+            params.delete(:proxyuserpwd)
+          end
+
+          params
+        end
       end
 
       # @return [ String ] The raw file URL associated with the given filename

--- a/lib/wpscan/db/vuln_api.rb
+++ b/lib/wpscan/db/vuln_api.rb
@@ -70,12 +70,21 @@ module WPScan
       # @return [ Hash ]
       # @note Those params can not be overriden by CLI options
       def self.default_request_params
-        @default_request_params ||= Browser.instance.default_request_params.merge(
-          headers: {
-            'User-Agent' => Browser.instance.default_user_agent,
-            'Authorization' => "Token token=#{token}"
-          }
-        )
+        @default_request_params ||= begin
+          params = Browser.instance.default_request_params.merge(
+            headers: {
+              'User-Agent' => Browser.instance.default_user_agent,
+              'Authorization' => "Token token=#{token}"
+            }
+          )
+
+          if ParsedCli.proxy_target_only
+            params.delete(:proxy)
+            params.delete(:proxyuserpwd)
+          end
+
+          params
+        end
       end
     end
   end

--- a/spec/app/controllers/vuln_api_spec.rb
+++ b/spec/app/controllers/vuln_api_spec.rb
@@ -14,8 +14,8 @@ describe WPScan::Controller::VulnApi do
     its(:cli_options) { should_not be_empty }
     its(:cli_options) { should be_a Array }
 
-    it 'contains to correct options' do
-      expect(controller.cli_options.map(&:to_sym)).to eq %i[api_token]
+    it 'contains the correct options' do
+      expect(controller.cli_options.map(&:to_sym)).to eq %i[api_token proxy_target_only]
     end
   end
 

--- a/spec/lib/db/vuln_api_spec.rb
+++ b/spec/lib/db/vuln_api_spec.rb
@@ -339,4 +339,62 @@ describe WPScan::DB::VulnApi do
       end
     end
   end
+
+  describe '#default_request_params' do
+    before do
+      WPScan::ParsedCli.options = rspec_parsed_options(cli_args)
+      WPScan::Browser.instance.load_options(WPScan::ParsedCli.options.dup)
+      api.instance_variable_set(:@default_request_params, nil)
+    end
+
+    after do
+      # Reset the Browser instance state so the proxy/flags set here don't leak into other specs
+      WPScan::Browser.instance.proxy = nil
+      WPScan::Browser.instance.proxy_auth = nil
+    end
+
+    context 'when --proxy is set' do
+      let(:cli_args) { '--url http://ex.lo/ --proxy http://127.0.0.1:8080' }
+
+      it 'includes the proxy in the params' do
+        expect(api.default_request_params[:proxy]).to eql 'http://127.0.0.1:8080'
+      end
+    end
+
+    context 'when --proxy is set with --proxy-auth' do
+      let(:cli_args) { '--url http://ex.lo/ --proxy http://127.0.0.1:8080 --proxy-auth user:pass' }
+
+      it 'includes the proxy and proxyuserpwd in the params' do
+        expect(api.default_request_params[:proxy]).to eql 'http://127.0.0.1:8080'
+        expect(api.default_request_params[:proxyuserpwd]).to eql 'user:pass'
+      end
+    end
+
+    context 'when --proxy is set with --proxy-target-only' do
+      let(:cli_args) { '--url http://ex.lo/ --proxy http://127.0.0.1:8080 --proxy-target-only' }
+
+      it 'does not include the proxy in the params' do
+        expect(api.default_request_params).to_not have_key(:proxy)
+      end
+    end
+
+    context 'when --proxy and --proxy-auth are set with --proxy-target-only' do
+      let(:cli_args) do
+        '--url http://ex.lo/ --proxy http://127.0.0.1:8080 --proxy-auth user:pass --proxy-target-only'
+      end
+
+      it 'does not include the proxy or proxyuserpwd in the params' do
+        expect(api.default_request_params).to_not have_key(:proxy)
+        expect(api.default_request_params).to_not have_key(:proxyuserpwd)
+      end
+    end
+
+    context 'when only --proxy-target-only is set (no --proxy)' do
+      let(:cli_args) { '--url http://ex.lo/ --proxy-target-only' }
+
+      it 'still produces valid params without a proxy' do
+        expect(api.default_request_params).to_not have_key(:proxy)
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Closes https://github.com/wpscanteam/wpscan/issues/1834

## Proposed changes

  * Add a new `--proxy-target-only` boolean CLI switch. When used together with `--proxy`, the proxy is applied only to requests made to the target site (`--url`) and is stripped from requests made to the  WPScan API (`wpscan.com`) and the database repository (`data.wpscan.org`). Has no effect unless `--proxy` is also set.
  * Implemented by deleting the `:proxy` and `:proxyuserpwd` keys from the request params in `DB::VulnApi.default_request_params` and `DB::Updater#request_params` when the flag is set.

  ## Why are these changes being made?

  The reporter's target site is only reachable via a local proxy (e.g. `socks5://127.0.0.1:1080`), and that proxy has no outbound internet access. Today, setting `--proxy` routes *all* traffic through it, including the WPScan API status/lookup calls and the DB updater hitting `data.wpscan.org`, so the scan aborts before it ever reaches the target. There was no way to scope the proxy to just target traffic.

  `--proxy-target-only` gives users in that topology (air-gapped / split-tunnel / local lab network) a way to use their local proxy for the target while letting API and DB-update requests take the direct internet route.

  ## Testing instructions

  A minimal local reproduction uses [mitmproxy](https://www.mitmproxy.org/) as an allowlist proxy that only lets traffic to the target host through and blocks everything else (so API / DB calls going through it will fail):

  ```bash
  brew install mitmproxy

  # Proxy that only allows requests whose destination host is your target; everything else → 403
  mitmdump -p 8081 --ssl-insecure  --set block_list=':!~d your-target.example.com:403'
  ```

  Then, in a separate shell:

  ```bash
  # 1) Without the new flag: API calls go through the proxy and get blocked.
  #    Expect: scan fails / no vulnerability data, 403s visible in mitmdump output.
  wpscan --url https://your-target.example.com \
         --api-token "$WPSCAN_API_TOKEN" \
         --proxy http://localhost:8081 \
         --disable-tls-checks

  # 2) With the new flag: API calls bypass the proxy and hit wpscan.com directly.
  #    Expect: scan completes, vulnerability data shown, mitmdump only logs target traffic.
  wpscan --url https://your-target.example.com \
         --api-token "$WPSCAN_API_TOKEN" \
         --proxy http://localhost:8081 \
         --proxy-target-only \
         --disable-tls-checks
  ```

  Notes:
  - `--disable-tls-checks` + `--ssl-insecure` are only needed because mitmproxy intercepts TLS; not required in proper proxy setups
  - To exercise the updater path too, force a DB refresh: run `wpscan --update` with and without `--proxy-target-only` — without the flag, the update should fail against the allowlist proxy; with it, the update should succeed.

