### PR TITLE
Properly set up coveralls parallel build step so we can get per-ruby-version coverage reports and also have proper master builds to compare to.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,22 @@ jobs:
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       run: bundle exec rspec
 
-    - name: Coveralls
-      uses: coverallsapp/github-action@master
+    - name: Coveralls (parallel)
+      uses: coverallsapp/github-action@v2
       continue-on-error: true
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
+        flag-name: ruby-${{ matrix.ruby }}
+        parallel: true
+
+  finish:
+    needs: build
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls finished
+      uses: coverallsapp/github-action@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        parallel-finished: true
+        carryforward: "ruby-3.3,ruby-3.4,ruby-4.0"


### PR DESCRIPTION
It was bothering me a little but that each PR says it does not have a coverage report from master to compare to, [example](https://github.com/wpscanteam/wpscan/pull/1975): 

<img width="896" height="197" alt="image" src="https://github.com/user-attachments/assets/944c848e-d429-4e53-a945-b5cd5e65bf82" />


so I looked what it would take to fix that. At least one issue seems to be that we run multiple builds and do not have that parallel config set up properly.

There are docs about it here: https://docs.coveralls.io/parallel-builds