### PR TITLE
Add basic integration tests for E2E WPScan functionality

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -90,8 +90,9 @@ jobs:
           --disable-tls-checks \
           --format json \
           --output scan-results.json \
-          --enumerate vp,vt \
-          --plugins-detection aggressive"
+          --enumerate p,t \
+          --plugins-detection aggressive \
+          --exclude-content-based"
 
         # Only add API token if it's set
         if [ -n "${WPSCAN_API_TOKEN}" ]; then

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -64,10 +64,10 @@ jobs:
         cd wordpress-test
         curl -k -f https://wordpress-test.ddev.site || (ddev logs && exit 1)
 
-    - name: Set up Ruby ${{ matrix.ruby || '3.3' }}
+    - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby || '3.3' }}
+        ruby-version: '4.0'
 
     - name: Install GEMs and build WPScan
       run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,31 +38,20 @@ jobs:
           --admin_email=test@example.com \
           --skip-email
 
-    - name: Install vulnerable plugins with known CVEs
+    - name: Install vulnerable plugins and theme
       run: |
         cd wordpress-test
-        # Contact Form 7 5.3.2 - Has known XSS vulnerability (CVE-2020-35489)
+        # Install plugins with known CVEs
         ddev exec wp plugin install contact-form-7 --version=5.3.2 --activate --path=wordpress
-
-        # Elementor 3.1.3 - Has known authenticated stored XSS (multiple CVEs)
         ddev exec wp plugin install elementor --version=3.1.3 --activate --path=wordpress
-
-        # WooCommerce 4.6.1 - Has known SQL injection (CVE-2021-32789)
         ddev exec wp plugin install woocommerce --version=4.6.1 --activate --path=wordpress
-
-        # Yoast SEO 15.5 - Has known XSS vulnerability
         ddev exec wp plugin install wordpress-seo --version=15.5 --activate --path=wordpress
 
-    - name: Install vulnerable theme
-      run: |
-        cd wordpress-test
-        # Twenty Nineteen 1.8 has known vulnerabilities
+        # Install theme with known vulnerabilities
         ddev exec wp theme install twentynineteen --version=1.8 --activate --path=wordpress
 
     - name: Verify WordPress site is accessible
-      run: |
-        cd wordpress-test
-        curl -k -f https://wordpress-test.ddev.site || (ddev logs && exit 1)
+      run: curl -k -f https://wordpress-test.ddev.site
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
@@ -84,38 +73,30 @@ jobs:
       env:
         WPSCAN_API_TOKEN: ${{ secrets.WPSCAN_API_TOKEN }}
       run: |
-        # Build WPScan command with optional API token
-        WPSCAN_CMD="bundle exec ruby -Ilib bin/wpscan \
+        # Verify API token is configured
+        if [ -z "${WPSCAN_API_TOKEN}" ]; then
+          echo "Error: WPSCAN_API_TOKEN secret is not configured"
+          exit 1
+        fi
+
+        # Run WPScan (exit code 5 = vulnerabilities found, which we expect)
+        set +e
+        bundle exec ruby -Ilib bin/wpscan \
           --url https://wordpress-test.ddev.site \
           --disable-tls-checks \
           --format json \
-          --output scan-results.json"
-
-        # Only add API token if it's set
-        if [ -n "${WPSCAN_API_TOKEN}" ]; then
-          echo "Using WPScan API token for vulnerability data"
-          WPSCAN_CMD="${WPSCAN_CMD} --api-token ${WPSCAN_API_TOKEN}"
-        else
-          echo "Warning: WPSCAN_API_TOKEN not set. Vulnerability data will be limited to local database only."
-        fi
-
-        # Run the scan
-        # Exit codes: 0=OK, 5=Vulnerabilities found (expected), others=error
-        set +e
-        eval $WPSCAN_CMD
+          --output scan-results.json \
+          --api-token "${WPSCAN_API_TOKEN}"
         EXIT_CODE=$?
         set -e
 
-        # Verify scan completed successfully
-        if [ "${EXIT_CODE}" -eq 5 ]; then
-          echo "✓ WPScan found vulnerabilities (exit code 5)"
-        elif [ "${EXIT_CODE}" -eq 0 ]; then
-          echo "✗ No vulnerabilities found - this is unexpected for our test"
+        # Verify we found vulnerabilities (exit code 5)
+        if [ "${EXIT_CODE}" -ne 5 ]; then
+          echo "✗ Expected exit code 5 (vulnerabilities found), got ${EXIT_CODE}"
           exit 1
-        else
-          echo "✗ WPScan failed with exit code ${EXIT_CODE}"
-          exit ${EXIT_CODE}
         fi
+
+        echo "✓ WPScan found vulnerabilities (exit code 5)"
 
     - name: Verify scan results
       run: |
@@ -127,9 +108,3 @@ jobs:
       with:
         name: integration-test-results
         path: scan-results.json
-
-    - name: Show DDEV logs on failure
-      if: failure()
-      run: |
-        cd wordpress-test
-        ddev logs

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,14 +41,10 @@ jobs:
     - name: Install vulnerable plugins and theme
       run: |
         cd wordpress-test
-        # Install plugins with known CVEs
-        ddev exec wp plugin install contact-form-7 --version=5.3.2 --activate --path=wordpress
-        ddev exec wp plugin install elementor --version=3.1.3 --activate --path=wordpress
-        ddev exec wp plugin install woocommerce --version=4.6.1 --activate --path=wordpress
-        ddev exec wp plugin install wordpress-seo --version=15.5 --activate --path=wordpress
-
-        # Install theme with known vulnerabilities
-        ddev exec wp theme install twentynineteen --version=1.8 --activate --path=wordpress
+        ddev exec wp plugin install contact-form-7 --version=5.3.2 --activate --path=wordpress 2>/dev/null
+        ddev exec wp plugin install woocommerce --version=4.6.1 --activate --path=wordpress 2>/dev/null
+        ddev exec wp plugin install wordpress-seo --version=15.5 --activate --path=wordpress 2>/dev/null
+        ddev exec wp theme install twentynineteen --version=1.8 --activate --path=wordpress 2>/dev/null
 
     - name: Verify WordPress site is accessible
       run: curl -k -f https://wordpress-test.ddev.site

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,6 +19,8 @@ jobs:
 
     - name: Set up DDEV
       uses: ddev/github-action-setup-ddev@v1
+      with:
+        autostart: false
 
     - name: Create WordPress test site
       run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -102,9 +102,21 @@ jobs:
         fi
 
         # Run the scan
-        eval $WPSCAN_CMD
+        # Exit codes: 0=OK, 1=CLI error, 2=Interrupted, 3=Exception, 4=Scan error, 5=Vulnerabilities found
+        eval $WPSCAN_CMD || EXIT_CODE=$?
+
+        if [ "${EXIT_CODE:-0}" -eq 5 ]; then
+          echo "✓ WPScan found vulnerabilities (exit code 5) - this is expected for our test!"
+        elif [ "${EXIT_CODE:-0}" -eq 0 ]; then
+          echo "⚠ Warning: WPScan completed but found no vulnerabilities (exit code 0)"
+          echo "This is unexpected - we installed vulnerable plugins/themes"
+        elif [ "${EXIT_CODE:-0}" -ne 0 ]; then
+          echo "✗ WPScan failed with exit code ${EXIT_CODE}"
+          exit ${EXIT_CODE}
+        fi
 
         # Show results for debugging
+        echo ""
         echo "=== Scan Results ==="
         cat scan-results.json | jq . || cat scan-results.json
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -89,10 +89,7 @@ jobs:
           --url https://wordpress-test.ddev.site \
           --disable-tls-checks \
           --format json \
-          --output scan-results.json \
-          --enumerate p,t \
-          --plugins-detection aggressive \
-          --exclude-content-based"
+          --output scan-results.json"
 
         # Only add API token if it's set
         if [ -n "${WPSCAN_API_TOKEN}" ]; then

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -99,37 +99,21 @@ jobs:
           echo "Warning: WPSCAN_API_TOKEN not set. Vulnerability data will be limited to local database only."
         fi
 
-        # Run the scan (capture both stdout/stderr for debugging)
-        # Exit codes: 0=OK, 1=CLI error, 2=Interrupted, 3=Exception, 4=Scan error, 5=Vulnerabilities found
-        set +e  # Temporarily disable errexit to capture output
-        eval $WPSCAN_CMD 2>&1 | tee /tmp/wpscan-output.log
+        # Run the scan
+        # Exit codes: 0=OK, 5=Vulnerabilities found (expected), others=error
+        set +e
+        eval $WPSCAN_CMD
         EXIT_CODE=$?
-        set -e  # Re-enable errexit
+        set -e
 
-        echo ""
-        echo "WPScan exit code: ${EXIT_CODE}"
-        echo ""
-
-        # Show results for debugging
-        if [ -f scan-results.json ]; then
-          echo "=== Scan Results JSON ==="
-          cat scan-results.json | jq . || cat scan-results.json
-          echo ""
-        else
-          echo "⚠ Warning: scan-results.json was not created"
-        fi
-
-        # Check exit code and determine success/failure
+        # Verify scan completed successfully
         if [ "${EXIT_CODE}" -eq 5 ]; then
-          echo "✓ WPScan found vulnerabilities (exit code 5) - this is expected for our test!"
+          echo "✓ WPScan found vulnerabilities (exit code 5)"
         elif [ "${EXIT_CODE}" -eq 0 ]; then
-          echo "⚠ Warning: WPScan completed but found no vulnerabilities (exit code 0)"
-          echo "This is unexpected - we installed vulnerable plugins/themes"
+          echo "✗ No vulnerabilities found - this is unexpected for our test"
+          exit 1
         else
           echo "✗ WPScan failed with exit code ${EXIT_CODE}"
-          echo ""
-          echo "=== WPScan Output ==="
-          cat /tmp/wpscan-output.log || echo "Could not read WPScan output"
           exit ${EXIT_CODE}
         fi
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -101,24 +101,39 @@ jobs:
           echo "Warning: WPSCAN_API_TOKEN not set. Vulnerability data will be limited to local database only."
         fi
 
-        # Run the scan
+        # Run the scan (capture both stdout/stderr for debugging)
         # Exit codes: 0=OK, 1=CLI error, 2=Interrupted, 3=Exception, 4=Scan error, 5=Vulnerabilities found
-        eval $WPSCAN_CMD || EXIT_CODE=$?
+        set +e  # Temporarily disable errexit to capture output
+        eval $WPSCAN_CMD 2>&1 | tee /tmp/wpscan-output.log
+        EXIT_CODE=$?
+        set -e  # Re-enable errexit
 
-        if [ "${EXIT_CODE:-0}" -eq 5 ]; then
-          echo "✓ WPScan found vulnerabilities (exit code 5) - this is expected for our test!"
-        elif [ "${EXIT_CODE:-0}" -eq 0 ]; then
-          echo "⚠ Warning: WPScan completed but found no vulnerabilities (exit code 0)"
-          echo "This is unexpected - we installed vulnerable plugins/themes"
-        elif [ "${EXIT_CODE:-0}" -ne 0 ]; then
-          echo "✗ WPScan failed with exit code ${EXIT_CODE}"
-          exit ${EXIT_CODE}
-        fi
+        echo ""
+        echo "WPScan exit code: ${EXIT_CODE}"
+        echo ""
 
         # Show results for debugging
-        echo ""
-        echo "=== Scan Results ==="
-        cat scan-results.json | jq . || cat scan-results.json
+        if [ -f scan-results.json ]; then
+          echo "=== Scan Results JSON ==="
+          cat scan-results.json | jq . || cat scan-results.json
+          echo ""
+        else
+          echo "⚠ Warning: scan-results.json was not created"
+        fi
+
+        # Check exit code and determine success/failure
+        if [ "${EXIT_CODE}" -eq 5 ]; then
+          echo "✓ WPScan found vulnerabilities (exit code 5) - this is expected for our test!"
+        elif [ "${EXIT_CODE}" -eq 0 ]; then
+          echo "⚠ Warning: WPScan completed but found no vulnerabilities (exit code 0)"
+          echo "This is unexpected - we installed vulnerable plugins/themes"
+        else
+          echo "✗ WPScan failed with exit code ${EXIT_CODE}"
+          echo ""
+          echo "=== WPScan Output ==="
+          cat /tmp/wpscan-output.log || echo "Could not read WPScan output"
+          exit ${EXIT_CODE}
+        fi
 
     - name: Verify scan results
       run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -84,14 +84,25 @@ jobs:
       env:
         WPSCAN_API_TOKEN: ${{ secrets.WPSCAN_API_TOKEN }}
       run: |
-        bundle exec ruby -Ilib bin/wpscan \
+        # Build WPScan command with optional API token
+        WPSCAN_CMD="bundle exec ruby -Ilib bin/wpscan \
           --url https://wordpress-test.ddev.site \
           --disable-tls-checks \
           --format json \
           --output scan-results.json \
           --enumerate vp,vt \
-          --plugins-detection aggressive \
-          --api-token "${WPSCAN_API_TOKEN}" || true
+          --plugins-detection aggressive"
+
+        # Only add API token if it's set
+        if [ -n "${WPSCAN_API_TOKEN}" ]; then
+          echo "Using WPScan API token for vulnerability data"
+          WPSCAN_CMD="${WPSCAN_CMD} --api-token ${WPSCAN_API_TOKEN}"
+        else
+          echo "Warning: WPSCAN_API_TOKEN not set. Vulnerability data will be limited to local database only."
+        fi
+
+        # Run the scan
+        eval $WPSCAN_CMD
 
         # Show results for debugging
         echo "=== Scan Results ==="

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,113 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [master]
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Set up DDEV
+      uses: ddev/github-action-setup-ddev@v1
+
+    - name: Create WordPress test site
+      run: |
+        mkdir wordpress-test
+        cd wordpress-test
+        ddev config --project-type=wordpress --php-version=8.1 --docroot=wordpress
+        ddev start
+        ddev exec wp core download --path=wordpress
+        ddev exec wp core install \
+          --path=wordpress \
+          --url=https://wordpress-test.ddev.site \
+          --title="WPScan Integration Test" \
+          --admin_user=admin \
+          --admin_password=password \
+          --admin_email=test@example.com \
+          --skip-email
+
+    - name: Install vulnerable plugins with known CVEs
+      run: |
+        cd wordpress-test
+        # Contact Form 7 5.3.2 - Has known XSS vulnerability (CVE-2020-35489)
+        ddev exec wp plugin install contact-form-7 --version=5.3.2 --activate --path=wordpress
+
+        # Elementor 3.1.3 - Has known authenticated stored XSS (multiple CVEs)
+        ddev exec wp plugin install elementor --version=3.1.3 --activate --path=wordpress
+
+        # WooCommerce 4.6.1 - Has known SQL injection (CVE-2021-32789)
+        ddev exec wp plugin install woocommerce --version=4.6.1 --activate --path=wordpress
+
+        # Yoast SEO 15.5 - Has known XSS vulnerability
+        ddev exec wp plugin install wordpress-seo --version=15.5 --activate --path=wordpress
+
+    - name: Install vulnerable theme
+      run: |
+        cd wordpress-test
+        # Twenty Nineteen 1.8 has known vulnerabilities
+        ddev exec wp theme install twentynineteen --version=1.8 --activate --path=wordpress
+
+    - name: Verify WordPress site is accessible
+      run: |
+        cd wordpress-test
+        curl -k -f https://wordpress-test.ddev.site || (ddev logs && exit 1)
+
+    - name: Set up Ruby ${{ matrix.ruby || '3.3' }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby || '3.3' }}
+
+    - name: Install GEMs and build WPScan
+      run: |
+        gem install bundler
+        bundle config force_ruby_platform true
+        bundle config path vendor/bundle
+        bundle install --jobs 4 --retry 3
+
+    - name: Update WPScan database
+      run: |
+        bundle exec ruby -Ilib bin/wpscan --update
+
+    - name: Run WPScan against test site
+      env:
+        WPSCAN_API_TOKEN: ${{ secrets.WPSCAN_API_TOKEN }}
+      run: |
+        bundle exec ruby -Ilib bin/wpscan \
+          --url https://wordpress-test.ddev.site \
+          --disable-tls-checks \
+          --format json \
+          --output scan-results.json \
+          --enumerate vp,vt \
+          --plugins-detection aggressive \
+          --api-token "${WPSCAN_API_TOKEN}" || true
+
+        # Show results for debugging
+        echo "=== Scan Results ==="
+        cat scan-results.json | jq . || cat scan-results.json
+
+    - name: Verify scan results
+      run: |
+        bundle exec ruby spec/integration/verify_results.rb scan-results.json
+
+    - name: Upload scan results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: integration-test-results
+        path: scan-results.json
+
+    - name: Show DDEV logs on failure
+      if: failure()
+      run: |
+        cd wordpress-test
+        ddev logs

--- a/spec/integration/verify_results.rb
+++ b/spec/integration/verify_results.rb
@@ -1,0 +1,172 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'json'
+
+# Integration test verification script
+# Verifies that WPScan correctly detects known vulnerabilities in test WordPress site
+
+results_file = ARGV[0]
+
+unless results_file && File.exist?(results_file)
+  puts 'Error: Please provide a valid scan results JSON file'
+  exit 1
+end
+
+results = JSON.parse(File.read(results_file))
+
+# Expected plugins with vulnerabilities
+EXPECTED_VULNERABLE_PLUGINS = {
+  'contact-form-7' => {
+    version: '5.3.2',
+    min_vulns: 1,
+    description: 'Contact Form 7 5.3.2 (CVE-2020-35489 XSS)'
+  },
+  'elementor' => {
+    version: '3.1.3',
+    min_vulns: 1,
+    description: 'Elementor 3.1.3 (authenticated stored XSS)'
+  },
+  'woocommerce' => {
+    version: '4.6.1',
+    min_vulns: 1,
+    description: 'WooCommerce 4.6.1 (CVE-2021-32789 SQL injection)'
+  },
+  'wordpress-seo' => {
+    version: '15.5',
+    min_vulns: 1,
+    description: 'Yoast SEO 15.5 (XSS vulnerability)'
+  }
+}.freeze
+
+# Expected theme vulnerabilities
+EXPECTED_VULNERABLE_THEMES = {
+  'twentynineteen' => {
+    version: '1.8',
+    min_vulns: 1,
+    description: 'Twenty Nineteen 1.8'
+  }
+}.freeze
+
+failures = []
+warnings = []
+
+puts '=' * 80
+puts 'WPScan Integration Test - Verification Results'
+puts '=' * 80
+puts
+
+# Verify WordPress was detected
+if results['version'].nil?
+  failures << 'WordPress version not detected'
+else
+  wp_version = results['version']['number']
+  puts "✓ WordPress detected: #{wp_version}"
+end
+
+puts
+
+# Verify plugins were detected
+puts 'Plugin Detection & Vulnerability Check:'
+puts '-' * 80
+
+EXPECTED_VULNERABLE_PLUGINS.each do |slug, expectations|
+  plugin_data = results.dig('plugins', slug)
+
+  if plugin_data.nil?
+    failures << "Plugin '#{slug}' not detected (#{expectations[:description]})"
+    puts "✗ #{slug}: NOT DETECTED"
+    next
+  end
+
+  detected_version = plugin_data.dig('version', 'number')
+  vulns = plugin_data['vulnerabilities'] || []
+
+  # Check version detection
+  if detected_version.nil?
+    warnings << "Plugin '#{slug}' detected but version not identified"
+    puts "⚠ #{slug}: Detected but version unknown (expected #{expectations[:version]})"
+  elsif detected_version != expectations[:version]
+    failures << "Expected #{slug} version #{expectations[:version]}, got #{detected_version}"
+    puts "✗ #{slug}: Wrong version (expected #{expectations[:version]}, got #{detected_version})"
+  else
+    puts "✓ #{slug}: Version #{detected_version} detected"
+  end
+
+  # Check vulnerabilities
+  if vulns.length < expectations[:min_vulns]
+    failures << "Expected at least #{expectations[:min_vulns]} vulnerabilities for #{slug}, found #{vulns.length}"
+    puts "  ✗ Vulnerabilities: Found #{vulns.length}, expected at least #{expectations[:min_vulns]}"
+  else
+    puts "  ✓ Vulnerabilities: Found #{vulns.length} (expected at least #{expectations[:min_vulns]})"
+    vulns.first(3).each do |vuln|
+      title = vuln['title'] || 'Unknown'
+      puts "    - #{title}"
+    end
+  end
+end
+
+puts
+
+# Verify themes were detected
+puts 'Theme Detection & Vulnerability Check:'
+puts '-' * 80
+
+EXPECTED_VULNERABLE_THEMES.each do |slug, expectations|
+  theme_data = results.dig('themes', slug)
+
+  if theme_data.nil?
+    failures << "Theme '#{slug}' not detected (#{expectations[:description]})"
+    puts "✗ #{slug}: NOT DETECTED"
+    next
+  end
+
+  detected_version = theme_data.dig('version', 'number')
+  vulns = theme_data['vulnerabilities'] || []
+
+  # Check version detection
+  if detected_version.nil?
+    warnings << "Theme '#{slug}' detected but version not identified"
+    puts "⚠ #{slug}: Detected but version unknown (expected #{expectations[:version]})"
+  elsif detected_version != expectations[:version]
+    failures << "Expected #{slug} version #{expectations[:version]}, got #{detected_version}"
+    puts "✗ #{slug}: Wrong version (expected #{expectations[:version]}, got #{detected_version})"
+  else
+    puts "✓ #{slug}: Version #{detected_version} detected"
+  end
+
+  # Check vulnerabilities
+  if vulns.length < expectations[:min_vulns]
+    failures << "Expected at least #{expectations[:min_vulns]} vulnerabilities for #{slug}, found #{vulns.length}"
+    puts "  ✗ Vulnerabilities: Found #{vulns.length}, expected at least #{expectations[:min_vulns]}"
+  else
+    puts "  ✓ Vulnerabilities: Found #{vulns.length} (expected at least #{expectations[:min_vulns]})"
+    vulns.first(3).each do |vuln|
+      title = vuln['title'] || 'Unknown'
+      puts "    - #{title}"
+    end
+  end
+end
+
+puts
+puts '=' * 80
+
+# Display summary
+if warnings.any?
+  puts
+  puts 'Warnings:'
+  warnings.each { |w| puts "  ⚠ #{w}" }
+end
+
+if failures.any?
+  puts
+  puts 'FAILED - Integration test failures:'
+  failures.each { |f| puts "  ✗ #{f}" }
+  puts
+  exit 1
+else
+  puts
+  puts '✓ All integration tests passed!'
+  puts
+  exit 0
+end

--- a/spec/integration/verify_results.rb
+++ b/spec/integration/verify_results.rb
@@ -112,7 +112,7 @@ theme_data = results['main_theme']
 
 if theme_data.nil?
   failures << "Theme not detected (expected #{EXPECTED_THEME[:description]})"
-  puts "✗ Theme: NOT DETECTED"
+  puts '✗ Theme: NOT DETECTED'
 else
   detected_slug = theme_data['slug']
   detected_version = theme_data.dig('version', 'number')
@@ -121,7 +121,7 @@ else
     failures << "Expected theme #{EXPECTED_THEME[:slug]}, got #{detected_slug}"
     puts "✗ Theme: Wrong theme (expected #{EXPECTED_THEME[:slug]}, got #{detected_slug})"
   elsif detected_version.nil?
-    warnings << "Theme detected but version not identified"
+    warnings << 'Theme detected but version not identified'
     puts "⚠ #{detected_slug}: Detected but version unknown (expected #{EXPECTED_THEME[:version]})"
   elsif detected_version != EXPECTED_THEME[:version]
     failures << "Expected #{detected_slug} version #{EXPECTED_THEME[:version]}, got #{detected_version}"
@@ -143,14 +143,13 @@ if warnings.any?
   warnings.each { |w| puts "  ⚠ #{w}" }
 end
 
+puts
 if failures.any?
-  puts
   puts 'FAILED - Integration test failures:'
   failures.each { |f| puts "  ✗ #{f}" }
   puts
   exit 1
 else
-  puts
   puts '✓ All integration tests passed!'
   puts
   exit 0

--- a/spec/integration/verify_results.rb
+++ b/spec/integration/verify_results.rb
@@ -16,16 +16,13 @@ end
 results = JSON.parse(File.read(results_file))
 
 # Expected plugins with vulnerabilities
+# NOTE: Using passive detection, so only plugins referenced on the homepage are detected.
+# Elementor is not included because it's not passively detected (not referenced on homepage).
 EXPECTED_VULNERABLE_PLUGINS = {
   'contact-form-7' => {
     version: '5.3.2',
     min_vulns: 1,
     description: 'Contact Form 7 5.3.2 (CVE-2020-35489 XSS)'
-  },
-  'elementor' => {
-    version: '3.1.3',
-    min_vulns: 1,
-    description: 'Elementor 3.1.3 (authenticated stored XSS)'
   },
   'woocommerce' => {
     version: '4.6.1',
@@ -39,13 +36,12 @@ EXPECTED_VULNERABLE_PLUGINS = {
   }
 }.freeze
 
-# Expected theme vulnerabilities
-EXPECTED_VULNERABLE_THEMES = {
-  'twentynineteen' => {
-    version: '1.8',
-    min_vulns: 1,
-    description: 'Twenty Nineteen 1.8'
-  }
+# Expected theme detection
+# NOTE: Theme is detected but may not have vulnerabilities in the database
+EXPECTED_THEME = {
+  slug: 'twentynineteen',
+  version: '1.8',
+  description: 'Twenty Nineteen 1.8'
 }.freeze
 
 failures = []
@@ -109,42 +105,31 @@ end
 puts
 
 # Verify themes were detected
-puts 'Theme Detection & Vulnerability Check:'
+puts 'Theme Detection:'
 puts '-' * 80
 
-EXPECTED_VULNERABLE_THEMES.each do |slug, expectations|
-  theme_data = results.dig('themes', slug)
+theme_data = results['main_theme']
 
-  if theme_data.nil?
-    failures << "Theme '#{slug}' not detected (#{expectations[:description]})"
-    puts "✗ #{slug}: NOT DETECTED"
-    next
-  end
-
+if theme_data.nil?
+  failures << "Theme not detected (expected #{EXPECTED_THEME[:description]})"
+  puts "✗ Theme: NOT DETECTED"
+else
+  detected_slug = theme_data['slug']
   detected_version = theme_data.dig('version', 'number')
-  vulns = theme_data['vulnerabilities'] || []
 
-  # Check version detection
-  if detected_version.nil?
-    warnings << "Theme '#{slug}' detected but version not identified"
-    puts "⚠ #{slug}: Detected but version unknown (expected #{expectations[:version]})"
-  elsif detected_version != expectations[:version]
-    failures << "Expected #{slug} version #{expectations[:version]}, got #{detected_version}"
-    puts "✗ #{slug}: Wrong version (expected #{expectations[:version]}, got #{detected_version})"
+  if detected_slug != EXPECTED_THEME[:slug]
+    failures << "Expected theme #{EXPECTED_THEME[:slug]}, got #{detected_slug}"
+    puts "✗ Theme: Wrong theme (expected #{EXPECTED_THEME[:slug]}, got #{detected_slug})"
+  elsif detected_version.nil?
+    warnings << "Theme detected but version not identified"
+    puts "⚠ #{detected_slug}: Detected but version unknown (expected #{EXPECTED_THEME[:version]})"
+  elsif detected_version != EXPECTED_THEME[:version]
+    failures << "Expected #{detected_slug} version #{EXPECTED_THEME[:version]}, got #{detected_version}"
+    puts "✗ #{detected_slug}: Wrong version (expected #{EXPECTED_THEME[:version]}, got #{detected_version})"
   else
-    puts "✓ #{slug}: Version #{detected_version} detected"
-  end
-
-  # Check vulnerabilities
-  if vulns.length < expectations[:min_vulns]
-    failures << "Expected at least #{expectations[:min_vulns]} vulnerabilities for #{slug}, found #{vulns.length}"
-    puts "  ✗ Vulnerabilities: Found #{vulns.length}, expected at least #{expectations[:min_vulns]}"
-  else
-    puts "  ✓ Vulnerabilities: Found #{vulns.length} (expected at least #{expectations[:min_vulns]})"
-    vulns.first(3).each do |vuln|
-      title = vuln['title'] || 'Unknown'
-      puts "    - #{title}"
-    end
+    vulns = theme_data['vulnerabilities'] || []
+    puts "✓ #{detected_slug}: Version #{detected_version} detected"
+    puts "  ℹ Vulnerabilities: Found #{vulns.length} (theme vulnerabilities not required for this test)"
   end
 end
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

## Proposed changes

* Add basic end-to-end integration tests using DDEV and GitHub Actions
* Tests install WordPress with vulnerable plugins/themes and verify WPScan detects them
* Verification script checks that expected vulnerabilities are found
* Tests run automatically on every PR and push to master
* This is an initial simple iteration that can be expanded later

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Integration tests provide confidence that WPScan works end-to-end in real-world scenarios, not just unit tests. This catches regressions in vulnerability detection, version identification, and plugin/theme enumeration. The tests use actual WordPress installations with known vulnerable plugins to ensure WPScan correctly identifies security issues.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Trust the CI?

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor grants Automattic Inc. the unlimited, non-exclusive right to reuse, modify, and relicense the code.

