### PR TITLE
Integrated opt_parse_validator gem into this same repository to increase ease of development.

### DIFF
--- a/lib/opt_parse_validator.rb
+++ b/lib/opt_parse_validator.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+# Gems
+require 'addressable/uri'
+require 'active_support/inflector'
+require 'active_support/core_ext/hash'
+# Standard Libs
+require 'optparse'
+require 'pathname'
+# Custom Libs
+require 'opt_parse_validator/errors'
+require 'opt_parse_validator/hacks'
+require 'opt_parse_validator/opts'
+require 'opt_parse_validator/version'
+require 'opt_parse_validator/config_files_loader_merger' # Could even create a gem out of it, as completely independent
+
+# Gem namespace
+module OptParseValidator
+  # Validator
+  class OptParser < OptionParser
+    attr_reader :symbols_used, :opts
+
+    def initialize(banner = nil, width = 32, indent = ' ' * 4)
+      @results      = {}
+      @symbols_used = []
+      @opts         = []
+
+      super
+    end
+
+    # @return [ OptParseValidator::ConfigFilesLoaderMerger ]
+    def config_files
+      @config_files ||= ConfigFilesLoaderMerger.new
+    end
+
+    # @param [ Array<OptBase> ] options
+    #
+    # @return [ Self ] For chaining #new.add.results
+    def add(*options)
+      options.each do |option|
+        check_option(option)
+
+        @opts << option
+        @symbols_used << option.to_sym
+
+        # Set the default option value if it exists
+        # The default value is not validated as it is provided by devs
+        # and should be set to the correct format/value directly
+        @results[option.to_sym] = option.default unless option.default.nil?
+
+        register_callback(option)
+      end
+
+      self
+    end
+
+    # @return [ Hash ]
+    def results(argv = default_argv)
+      load_config_files
+      parse!(argv)
+      post_processing
+
+      @results
+    rescue StandardError => e
+      # Raise it as an OptParseValidator::Error if not already one
+      raise e.is_a?(Error) ? e.class : Error, e.message
+    end
+
+    # @return [ String ] The simplified help (without any of the advanced option/s listed)
+    def simple_help
+      help = to_s
+
+      # Removes all advanced help messages
+      @opts.select(&:advanced?).each do |opt|
+        messages_pattern = //
+
+        opt.help_messages.each do |msg|
+          messages_pattern = /#{messages_pattern}\s*#{Regexp.escape(msg)}/
+        end
+
+        pattern = /\s*#{Regexp.escape(opt.option[0..1].select { |o| o[0] == '-' }.join(', '))}#{messages_pattern}/
+
+        help.gsub!(pattern, '')
+      end
+
+      help
+    end
+
+    # @return [ String ] The full help, with the advanced option/s listed
+    def full_help
+      to_s
+    end
+
+    protected
+
+    # Ensures the opt given is valid
+    #
+    # @param [ OptBase ] opt
+    #
+    # @return [ void ]
+    def check_option(opt)
+      raise Error, "The option is not an OptBase, #{opt.class} supplied" unless opt.is_a?(OptBase)
+      raise Error, "The option #{opt.to_sym} is already used !" if @symbols_used.include?(opt.to_sym)
+    end
+
+    # @param [ OptBase ] opt
+    #
+    # @return [ void ]
+    def register_callback(opt)
+      on(*opt.option) do |arg|
+        if opt.alias?
+          parse!(opt.alias_for.split)
+        else
+          @results[opt.to_sym] = opt.normalize(opt.validate(arg))
+        end
+      rescue StandardError => e
+        # Adds the long option name to the message
+        # And raises it as an OptParseValidator::Error if not already one
+        # e.g --proxy Invalid Scheme format.
+        raise e.is_a?(Error) ? e.class : Error, "#{opt.to_long} #{e}"
+      end
+    end
+
+    # @return [ Void ]
+    def load_config_files
+      files_data = config_files.parse
+
+      @opts.each do |opt|
+        next unless files_data.key?(opt.to_sym)
+
+        begin
+          @results[opt.to_sym] = opt.normalize(opt.validate(files_data[opt.to_sym].to_s))
+        rescue StandardError => e
+          # Adds the long option name to the message
+          # And raises it as an OptParseValidator::Error if not already one
+          # e.g --proxy Invalid Scheme format.
+          raise e.is_a?(Error) ? e.class : Error, "#{opt.to_long} #{e}"
+        end
+      end
+    end
+
+    # Ensure that all required options are supplied
+    # Should be overriden to modify the behavior
+    #
+    # @return [ Void ]
+    def post_processing
+      @opts.each do |opt|
+        raise NoRequiredOption, "The option #{opt.to_long} is required" if opt.required? && !@results.key?(opt.to_sym)
+
+        next if opt.required_unless.empty? || @results.key?(opt.to_sym)
+
+        fail_msg = 'One of the following options is required: ' \
+                   "#{opt.to_long}, --#{opt.required_unless.join(', --').tr('_', '-')}"
+
+        raise NoRequiredOption, fail_msg unless opt.required_unless.any? do |sym|
+          @results.key?(sym)
+        end
+      end
+    end
+  end
+end

--- a/lib/opt_parse_validator/config_files_loader_merger.rb
+++ b/lib/opt_parse_validator/config_files_loader_merger.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative 'config_files_loader_merger/base'
+require_relative 'config_files_loader_merger/json'
+require_relative 'config_files_loader_merger/yml'
+
+# :nocov:
+# @param [ String ] path The path of the file to load
+def yaml_safe_load(path)
+  if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1') # Ruby 2.6
+    YAML.safe_load_file(path, permitted_classes: [Regexp]) || {}
+  else
+    YAML.safe_load_file(path, [Regexp]) || {}
+  end
+end
+# :nocov:
+
+module OptParseValidator
+  # Options Files container
+  class ConfigFilesLoaderMerger < Array
+    # @return [ Array<String> ] The downcased supported extensions list
+    def self.supported_extensions
+      extensions = ConfigFile.constants.select do |const|
+        name = ConfigFile.const_get(const)
+        name.is_a?(Class) && name != ConfigFile::Base
+      end
+
+      extensions.map { |sym| sym.to_s.downcase }
+    end
+
+    attr_accessor :result_key
+
+    # @param [ String ] file_path
+    #
+    # @return [ Self ]
+    def <<(file_path)
+      return self unless File.exist?(file_path)
+
+      ext = File.extname(file_path).delete('.')
+
+      unless self.class.supported_extensions.include?(ext)
+        raise Error,
+              "The option file's extension '#{ext}' is not supported"
+      end
+
+      super(ConfigFile.const_get(ext.upcase).new(file_path))
+    end
+
+    # @params [ Hash ] opts
+    #
+    # @return [ Hash ]
+    def parse
+      result = {}
+
+      each { |config_file| result.deep_merge!(config_file.parse) }
+
+      result = result[result_key] || {} if result_key
+
+      result.deep_symbolize_keys
+    end
+  end
+end

--- a/lib/opt_parse_validator/config_files_loader_merger/base.rb
+++ b/lib/opt_parse_validator/config_files_loader_merger/base.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  class ConfigFilesLoaderMerger < Array
+    module ConfigFile
+      # Base class, #parse should be implemented in child classes
+      class Base
+        attr_reader :path
+
+        # @param [ String ] path The file path of the option file
+        def initialize(path)
+          @path = path
+        end
+
+        # @return [ Hash ] a { 'key' => value } hash
+        def parse
+          raise NotImplementedError
+        end
+
+        def ==(other)
+          path == other.path
+        end
+      end
+    end
+  end
+end

--- a/lib/opt_parse_validator/config_files_loader_merger/json.rb
+++ b/lib/opt_parse_validator/config_files_loader_merger/json.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module OptParseValidator
+  class ConfigFilesLoaderMerger < Array
+    module ConfigFile
+      # Json Implementation
+      class JSON < Base
+        # @return [ Hash ] a { 'key' => value } hash
+        def parse
+          ::JSON.parse(File.read(path))
+        end
+      end
+    end
+  end
+end

--- a/lib/opt_parse_validator/config_files_loader_merger/yml.rb
+++ b/lib/opt_parse_validator/config_files_loader_merger/yml.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module OptParseValidator
+  class ConfigFilesLoaderMerger < Array
+    module ConfigFile
+      # Yaml Implementation
+      class YML < Base
+        # @return [ Hash ] a { 'key' => value } hash
+        def parse
+          yaml_safe_load(path)
+        end
+      end
+    end
+  end
+end

--- a/lib/opt_parse_validator/errors.rb
+++ b/lib/opt_parse_validator/errors.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  class Error < RuntimeError
+  end
+
+  class NoRequiredOption < Error
+  end
+end

--- a/lib/opt_parse_validator/hacks.rb
+++ b/lib/opt_parse_validator/hacks.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class OptionParser
+  # Hack to suppress the completion (except for the -h/--help) which was leading to
+  # unwanted behaviours
+  # See https://github.com/wpscanteam/CMSScanner/issues/2
+  module Completion
+    class << self
+      alias original_candidate candidate
+
+      # rubocop:disable Style/OptionalBooleanParameter
+      def candidate(key, icase = false, pat = nil, &)
+        # Maybe also do this for -v/--version ?
+        key == 'h' ? original_candidate('help', icase, pat, &) : []
+      end
+      # rubocop:enable Style/OptionalBooleanParameter
+    end
+  end
+end

--- a/lib/opt_parse_validator/opts.rb
+++ b/lib/opt_parse_validator/opts.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+%w[
+  base string integer positive_integer choice boolean uri url proxy credentials
+  path file_path directory_path array integer_range multi_choices regexp headers
+  smart_list alias
+].each do |opt|
+  require "opt_parse_validator/opts/#{opt}"
+end

--- a/lib/opt_parse_validator/opts/alias.rb
+++ b/lib/opt_parse_validator/opts/alias.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  # Implementation of the Alias Option
+  class OptAlias < OptBase
+    def initialize(option, attrs = {})
+      raise Error, 'The :alias_for attribute is required' unless attrs.key?(:alias_for)
+
+      super
+    end
+
+    def append_help_messages
+      super
+
+      option << "Alias for #{alias_for}"
+    end
+
+    # @return [ String ]
+    def alias_for
+      @alias_for ||= attrs[:alias_for]
+    end
+
+    # @return [ Boolean ]
+    def alias?
+      true
+    end
+  end
+end

--- a/lib/opt_parse_validator/opts/array.rb
+++ b/lib/opt_parse_validator/opts/array.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  # Implementation of the Array Option
+  class OptArray < OptBase
+    # @return [ Void ]
+    def append_help_messages
+      option << "Separator to use between the values: '#{separator}'"
+
+      super
+    end
+
+    # @param [ String ] value
+    #
+    # @return [ Array ]
+    def validate(value)
+      super.split(separator)
+    end
+
+    # @return [ String ] The separator used to split the string into an array
+    def separator
+      attrs[:separator] || ','
+    end
+
+    # See OptBase#normalize
+    # @param [ Array ] values
+    def normalize(values)
+      values.each_with_index do |value, index|
+        values[index] = super(value)
+      end
+      values
+    end
+  end
+end

--- a/lib/opt_parse_validator/opts/base.rb
+++ b/lib/opt_parse_validator/opts/base.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  # Base Option
+  # This Option should not be called, children should be used.
+  class OptBase
+    attr_writer :required
+    attr_reader :option, :attrs
+
+    # @param [ Array ] option See OptionParser#on
+    # @param [ Hash ] attrs
+    # @option attrs  [ Boolean ] :required
+    # @options attrs [ Array<Symbol>, Symbol ] :required_unless
+    # @option attrs  [ Mixed ] :default The default value to use if the option is not supplied
+    # @option attrs  [ Mixed ] :value_if_empty The value to use if no argument has been supplied
+    # @option attrs  [ Array<Symbol> ] :normalize See #normalize
+    #
+    # @note The :default and :normalize 'logics' are done in OptParseValidator::OptParser#add_option
+    def initialize(option, attrs = {})
+      @option = option
+      @attrs  = attrs
+
+      # TODO: incompatible attributes, ie required and require_unless at the same time
+
+      append_help_messages
+    end
+
+    # @return [ Void ]
+    def append_help_messages
+      option << "Default: #{help_message_for_default}" if default
+      option << "Value if no argument supplied: #{value_if_empty}" if value_if_empty
+      option << 'This option is mandatory' if required?
+      return if required_unless.empty?
+
+      option << "This option is mandatory unless #{required_unless.join(' or ')} is/are supplied"
+    end
+
+    def help_message_for_default
+      default.to_s
+    end
+
+    # @return [ Boolean ]
+    def required?
+      @required ||= attrs[:required]
+    end
+
+    def required_unless
+      @required_unless ||= Array(attrs[:required_unless])
+    end
+
+    # @return [ Mixed ]
+    def default
+      attrs[:default]
+    end
+
+    # @return [ Array<Mixed> ]
+    def choices
+      attrs[:choices]
+    end
+
+    # @return [ Mixed ]
+    def value_if_empty
+      attrs[:value_if_empty]
+    end
+
+    # @return [ Boolean ]
+    def alias?
+      false
+    end
+
+    # @return [ Boolean ]
+    def advanced?
+      attrs[:advanced] ? true : false
+    end
+
+    # @param [ String ] value
+    def validate(value)
+      if value.nil? || value.to_s.empty?
+        raise Error, 'Empty option value supplied' if value_if_empty.nil?
+
+        return value_if_empty
+      end
+      value
+    end
+
+    # Apply each methods from attrs[:normalize] to the value if possible
+    # User input should not be used in this attrs[:normalize]
+    #
+    # e.g: normalize: :to_sym will return the symbol of the value
+    #      normalize: [:to_sym, :upcase] Will return the upercased symbol
+    #
+    # @param [ Mixed ] value
+    #
+    # @return [ Mixed ]
+    def normalize(value)
+      Array(attrs[:normalize]).each do |method|
+        next unless method.is_a?(Symbol)
+
+        value = value.send(method) if value.respond_to?(method)
+      end
+
+      value
+    end
+
+    # @return [ Symbol ]
+    def to_sym
+      unless @symbol
+        long_option = to_long
+
+        raise Error, "Could not find option symbol for #{option}" unless long_option
+
+        @symbol = long_option.delete_prefix('--').tr('-', '_').to_sym
+      end
+      @symbol
+    end
+
+    # @return [ String ] The raw long option (e.g: --proxy)
+    def to_long
+      option.each do |option_attr|
+        if option_attr.start_with?('--')
+          return option_attr.gsub(/ .*$/, '')
+                            .gsub(/\[[^\]]+\]/, '')
+        end
+      end
+      nil
+    end
+
+    # @return [ String ]
+    def to_s
+      to_sym.to_s
+    end
+
+    # @return [ Array<String> ]
+    def help_messages
+      first_message_index = option.index { |e| e[0] != '-' }
+
+      return [] unless first_message_index
+
+      option[first_message_index..]
+    end
+  end
+end

--- a/lib/opt_parse_validator/opts/boolean.rb
+++ b/lib/opt_parse_validator/opts/boolean.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  # Implementation of the Boolean Option
+  class OptBoolean < OptBase
+    TRUE_PATTERN  = /\A(true|t|yes|y|1)\z/i
+    FALSE_PATTERN = /\A(false|f|no|n|0)\z/i
+
+    # @return [ Boolean ]
+    def validate(value)
+      value = value.to_s
+
+      return true if value.match(TRUE_PATTERN)
+      return false if value.match(FALSE_PATTERN)
+
+      raise Error, 'Invalid boolean value, expected true|t|yes|y|1|false|f|no|n|0'
+    end
+  end
+end

--- a/lib/opt_parse_validator/opts/choice.rb
+++ b/lib/opt_parse_validator/opts/choice.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  # Implementation of the Choice Option
+  class OptChoice < OptBase
+    # @param [ Array ] option See OptBase#new
+    # @param [ Hash ] attrs
+    #   :choices [ Array ] The available choices (mandatory)
+    #   :case_sensitive [ Boolean ] Default: false
+    def initialize(option, attrs = {})
+      raise Error, 'The :choices attribute is mandatory' unless attrs.key?(:choices)
+      raise Error, 'The :choices attribute must be an array' unless attrs[:choices].is_a?(Array)
+
+      super
+    end
+
+    # @return [ Void ]
+    def append_help_messages
+      super
+
+      option << "Available choices: #{choices.join(', ')}"
+    end
+
+    # @return [ String ]
+    # If :case_sensitive if false (or nil), the downcased value of the choice
+    # will be returned
+    def validate(value)
+      value = +value.to_s
+
+      unless attrs[:case_sensitive]
+        value.downcase!
+        choices.map!(&:downcase)
+      end
+
+      unless choices.include?(value)
+        raise Error, "'#{value}' is not a valid choice, expected one " \
+                     "of the followings: #{choices.join(',')}"
+      end
+
+      value
+    end
+  end
+end

--- a/lib/opt_parse_validator/opts/credentials.rb
+++ b/lib/opt_parse_validator/opts/credentials.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  # Implementation of the Credentials Option
+  class OptCredentials < OptBase
+    # @return [ Hash ] A hash containing the :username and :password
+    def validate(value)
+      raise Error, 'Incorrect credentials format, username:password expected' unless value.index(':')
+
+      creds = value.split(':', 2)
+
+      { username: creds[0], password: creds[1] }
+    end
+  end
+end

--- a/lib/opt_parse_validator/opts/directory_path.rb
+++ b/lib/opt_parse_validator/opts/directory_path.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  # Implemetantion of the DirectoryPath Option
+  class OptDirectoryPath < OptPath
+    def initialize(option, attrs = {})
+      super
+
+      @attrs.merge!(directory: true)
+    end
+
+    # @param [ Pathname ] path
+    def check_create(path)
+      FileUtils.mkdir_p(path.to_s)
+    end
+  end
+end

--- a/lib/opt_parse_validator/opts/file_path.rb
+++ b/lib/opt_parse_validator/opts/file_path.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  # Implementation of the FilePath Option
+  class OptFilePath < OptPath
+    # @param [ Array ] option See OptBase#new
+    # @param [ Hash ] attrs See OptPath#new
+    # :extensions [ Array | String ] The allowed extension(s)
+    def initialize(option, attrs = {})
+      super
+
+      @attrs.merge!(file: true)
+    end
+
+    # @param [ Pathname ] path
+    def check_create(path)
+      return if File.exist?(path.to_s)
+
+      FileUtils.mkdir_p(path.parent.to_s)
+      FileUtils.touch(path.to_s)
+    end
+
+    def allowed_attrs
+      # :extensions is put at the first place
+      [:extensions] + super
+    end
+
+    def check_extensions(path)
+      return if Array(attrs[:extensions]).include?(path.extname.delete('.'))
+
+      raise Error, "The extension of '#{path}' is not allowed"
+    end
+  end
+end

--- a/lib/opt_parse_validator/opts/headers.rb
+++ b/lib/opt_parse_validator/opts/headers.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  # Implementation of the Headers Option
+  class OptHeaders < OptBase
+    # @return [ Void ]
+    def append_help_messages
+      super
+
+      option << "Separator to use between the headers: '; '"
+      option << "Examples: 'X-Forwarded-For: 127.0.0.1', 'X-Forwarded-For: 127.0.0.1; Another: aaa'"
+    end
+
+    # @param [ String ] value
+    #
+    # @return [ Hash ] The parsed headers in a hash, with { 'key' => 'value' } format
+    def validate(value)
+      values = super.chomp(';').split('; ')
+
+      headers = {}
+
+      values.each do |header|
+        raise Error, "Malformed header: '#{header}'" unless header.index(':')
+
+        val = header.split(':', 2)
+
+        headers[val[0].strip] = val[1].strip
+      end
+
+      headers
+    end
+  end
+end

--- a/lib/opt_parse_validator/opts/integer.rb
+++ b/lib/opt_parse_validator/opts/integer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  # Implementation of the Integer Option
+  class OptInteger < OptBase
+    # @param [ String ] value
+    #
+    # @return [ Integer ]
+    def validate(value)
+      raise Error, "#{value} is not an integer" if value.to_i.to_s != value
+
+      value.to_i
+    end
+  end
+end

--- a/lib/opt_parse_validator/opts/integer_range.rb
+++ b/lib/opt_parse_validator/opts/integer_range.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  # Implementation of the Integer Range Option
+  class OptIntegerRange < OptBase
+    # @return [ Void ]
+    def append_help_messages
+      option << "Range separator to use: '#{separator}'"
+
+      super
+    end
+
+    # @param [ String ] value
+    #
+    # @return [ Range ]
+    def validate(value)
+      a = super.split(separator)
+
+      raise Error, "Incorrect number of ranges found: #{a.size}, should be 2" unless a.size == 2
+
+      first_integer = a.first.to_i
+      last_integer  = a.last.to_i
+
+      unless first_integer.to_s == a.first && last_integer.to_s == a.last
+        raise Error,
+              'Argument is not a valid integer range'
+      end
+
+      (first_integer..last_integer)
+    end
+
+    # @return [ String ]
+    def separator
+      attrs[:separator] || '-'
+    end
+  end
+end

--- a/lib/opt_parse_validator/opts/multi_choices.rb
+++ b/lib/opt_parse_validator/opts/multi_choices.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  # Implementation of the MultiChoices Option
+  class OptMultiChoices < OptArray
+    # @param [ Array ] option See OptBase#new
+    # @param [ Hash ] attrs
+    # @option attrs [ Hash ] :choices
+    # @option attrs [ Array<Array> ] :incompatible
+    # @options attrs [ String ] :separator See OptArray#new
+    def initialize(option, attrs = {})
+      raise Error, 'The :choices attribute is mandatory' unless attrs.key?(:choices)
+      raise Error, 'The :choices attribute must be a hash' unless attrs[:choices].is_a?(Hash)
+
+      super
+    end
+
+    def append_help_messages
+      option << 'Available Choices:'
+
+      append_choices_help_messages
+
+      super
+
+      append_incompatible_help_messages
+    end
+
+    def append_choices_help_messages
+      max_spaces = choices.keys.max_by(&:size).size
+
+      choices.each do |key, opt|
+        first_line_prefix  = " #{key} #{' ' * (max_spaces - key.length)}"
+        other_lines_prefix = ' ' * first_line_prefix.size
+
+        opt_help_messages(opt).each_with_index do |message, index|
+          option << "#{index.zero? ? first_line_prefix : other_lines_prefix} #{message}"
+        end
+      end
+    end
+
+    def help_message_for_default
+      msg = +''
+
+      default.each do |key, value|
+        msg << if value == true
+                 key.to_s.titleize
+               else
+                 "#{key.to_s.titleize}: #{value}"
+               end
+        msg << ', '
+      end
+
+      msg.chomp(', ')
+    end
+
+    # @param [ OptBase ] opt
+    #
+    # @return [ Array<String> ]
+    def opt_help_messages(opt)
+      opt.help_messages.empty? ? [opt.to_s.humanize] : opt.help_messages
+    end
+
+    def append_incompatible_help_messages
+      return if incompatible.empty?
+
+      option << 'Incompatible choices (only one of each group/s can be used):'
+
+      incompatible.each do |a|
+        option << " - #{a.join(', ')}"
+      end
+    end
+
+    # @param [ String ] value
+    #
+    # @return [ Hash ]
+    def validate(value)
+      results = {}
+
+      super.each do |item|
+        opt = choices[item.to_sym]
+
+        if opt
+          opt_value = opt.value_if_empty.nil? || opt.value_if_empty
+        else
+          opt, opt_value = value_from_pattern(item)
+        end
+
+        results[opt.to_sym] = opt.normalize(opt.validate(opt_value))
+      end
+
+      verify_compatibility(results)
+    end
+
+    # @return [ Array ]
+    def value_from_pattern(item)
+      choices.each do |key, opt|
+        next unless item =~ /\A#{key}(.*)\z/
+
+        return [opt, Regexp.last_match[1]]
+      end
+
+      raise Error, "Unknown choice: #{item}"
+    end
+
+    # @return [ Array<Array<Symbol>> ]
+    def incompatible
+      Array(attrs[:incompatible])
+    end
+
+    # @param [ Hash ] values
+    #
+    # @return [ Hash ]
+    def verify_compatibility(values)
+      incompatible.each do |a|
+        last_match = ''
+
+        a.each do |key|
+          sym = choices[key].to_sym
+
+          next unless values.key?(sym)
+
+          raise Error, "Incompatible choices detected: #{last_match}, #{key}" unless last_match.empty?
+
+          last_match = key
+        end
+      end
+      values
+    end
+
+    # No normalization
+    def normalize(value)
+      value
+    end
+  end
+end

--- a/lib/opt_parse_validator/opts/path.rb
+++ b/lib/opt_parse_validator/opts/path.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  # Implementation of the Path Option
+  class OptPath < OptBase
+    # Initialize attrs:
+    #
+    # :create     if set to true, will create the path
+    #
+    # :exists     if set to false, will ignore the file? and directory? checks
+    #
+    # :file       Check if the path is a file
+    # :directory  Check if the path is a directory
+    #
+    # :executable
+    # :readable
+    # :writable
+    #
+
+    # @param [ String ] value
+    #
+    # @return [ String ]
+    def validate(value)
+      path = Pathname.new(value)
+
+      allowed_attrs.each do |key|
+        method = "check_#{key}"
+        send(method, path) if respond_to?(method) && attrs[key]
+      end
+
+      path.to_s
+    end
+
+    def allowed_attrs
+      %i[create file directory executable readable writable]
+    end
+
+    # check_create is implemented in the file_path and directory_path opts
+
+    # @param [ Pathname ] path
+    def check_file(path)
+      raise Error, "The path '#{path}' does not exist or is not a file" unless path.file? || attrs[:exists] == false
+    end
+
+    # @param [ Pathname ] path
+    def check_directory(path)
+      return if path.directory? || attrs[:exists] == false
+
+      raise Error,
+            "The path '#{path}' does not exist or is not a directory"
+    end
+
+    # @param [ Pathname ] path
+    def check_executable(path)
+      raise Error, "The path '#{path}' is not executable" unless path.executable?
+    end
+
+    # @param [ Pathname ] path
+    def check_readable(path)
+      raise Error, "The path '#{path}' is not readable" unless path.readable?
+    end
+
+    # If the path does not exist, it will check for the parent
+    # directory write permission
+    #
+    # @param [ Pathname ] path
+    def check_writable(path)
+      raise Error, "The path '#{path}' is not writable" if (path.exist? && !path.writable?) || !path.parent.writable?
+    end
+  end
+end

--- a/lib/opt_parse_validator/opts/positive_integer.rb
+++ b/lib/opt_parse_validator/opts/positive_integer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  # Implementation of the Positive Integer Option
+  class OptPositiveInteger < OptInteger
+    # @param [ String ] value
+    #
+    # @return [ Integer ]
+    def validate(value)
+      i = super
+      raise Error, "#{i} is not > 0" unless i.positive?
+
+      i
+    end
+  end
+end

--- a/lib/opt_parse_validator/opts/proxy.rb
+++ b/lib/opt_parse_validator/opts/proxy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  # Implementation of the Proxy Option
+  class OptProxy < OptURI
+  end
+end

--- a/lib/opt_parse_validator/opts/regexp.rb
+++ b/lib/opt_parse_validator/opts/regexp.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  # Implementation of the Regexp Option
+  # See http://ruby-doc.org/core-2.2.1/Regexp.html#method-c-new for expected values in :options
+  class OptRegexp < OptBase
+    # @param [ String ] value
+    #
+    # @return [ Regexp ]
+    def validate(value)
+      Regexp.new(super, attrs[:options])
+    end
+  end
+end

--- a/lib/opt_parse_validator/opts/smart_list.rb
+++ b/lib/opt_parse_validator/opts/smart_list.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  # Implementation of the SmartList Option
+  # Such option allow users to supply a list like
+  # - name1
+  # - name1,name2,name3
+  # - /tmp/names.txt
+  class OptSmartList < OptArray
+    # @return [ Void ]
+    def append_help_messages
+      super
+      # removes the help message from OptArray about the separator as useless here
+      # can't use option as it's an attr_reader only
+      @option -= ["Separator to use between the values: '#{separator}'"]
+
+      option << "Examples: 'a1', '#{%w[a1 a2 a3].join(separator)}', '/tmp/a.txt'"
+    end
+
+    # @param [ String ] value
+    #
+    # @return [ Array<String> ]
+    def validate(value)
+      # Might be a better way to do this especially with a big file
+      File.open(value) { |f| f.map(&:chomp) }
+    rescue Errno::ENOENT
+      super
+    end
+  end
+end

--- a/lib/opt_parse_validator/opts/string.rb
+++ b/lib/opt_parse_validator/opts/string.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  # Alias of OptBase
+  # Used for convenience
+  class OptString < OptBase
+  end
+end

--- a/lib/opt_parse_validator/opts/uri.rb
+++ b/lib/opt_parse_validator/opts/uri.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  # Implementation of the URI Option
+  class OptURI < OptBase
+    # return [ Void ]
+    def append_help_messages
+      option << "Allowed Protocols: #{allowed_protocols.join(', ')}" unless allowed_protocols.empty?
+      option << "Default Protocol if none provided: #{default_protocol}" if default_protocol
+
+      super
+    end
+
+    # @return [ Array<String> ]
+    def allowed_protocols
+      @allowed_protocols ||= Array(attrs[:protocols]).map(&:downcase)
+    end
+
+    # The default protocol (or scheme) to use if none was given
+    def default_protocol
+      @default_protocol ||= attrs[:default_protocol]&.downcase
+    end
+
+    # @param [ String ] value
+    #
+    # @return [ String ]
+    def validate(value)
+      uri = Addressable::URI.parse(value)
+
+      uri = Addressable::URI.parse("#{default_protocol}://#{value}") if !uri.scheme && default_protocol
+
+      unless allowed_protocols.empty? || allowed_protocols.include?(uri.scheme&.downcase)
+        # For future refs: will have to check if the uri.scheme exists,
+        # otherwise it means that the value was empty
+        raise Addressable::URI::InvalidURIError
+      end
+
+      uri.to_s
+    end
+  end
+end

--- a/lib/opt_parse_validator/opts/url.rb
+++ b/lib/opt_parse_validator/opts/url.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module OptParseValidator
+  # Implementation of the URL Option
+  class OptURL < OptURI
+    # @return [ Array ] The allowed protocols
+    def allowed_protocols
+      %w[http https]
+    end
+  end
+end

--- a/lib/opt_parse_validator/version.rb
+++ b/lib/opt_parse_validator/version.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Gem Version
+module OptParseValidator
+  VERSION = '1.10.1'
+end

--- a/spec/fixtures/opt_parse_validator/advanced_help/no_advanced.txt
+++ b/spec/fixtures/opt_parse_validator/advanced_help/no_advanced.txt
@@ -1,0 +1,4 @@
+Usage: rspec [options]
+    -v, --verbose                    Verbose
+    -u, --url URL                    Allowed Protocols: http, https
+                                     This option is mandatory

--- a/spec/fixtures/opt_parse_validator/advanced_help/with_advanced.txt
+++ b/spec/fixtures/opt_parse_validator/advanced_help/with_advanced.txt
@@ -1,0 +1,8 @@
+Usage: rspec [options]
+    -v, --verbose                    Verbose
+    -u, --url URL                    Allowed Protocols: http, https
+                                     This option is mandatory
+        --[no-]banner                aaa aaa
+    -s, --short ARG                  Option
+                                     Multi Line
+    -a, --all                        Short and long option

--- a/spec/fixtures/opt_parse_validator/config_files_loader_merger/date_class.yml
+++ b/spec/fixtures/opt_parse_validator/config_files_loader_merger/date_class.yml
@@ -1,0 +1,1 @@
+date: !ruby/date 2010-02-11

--- a/spec/fixtures/opt_parse_validator/config_files_loader_merger/default.json
+++ b/spec/fixtures/opt_parse_validator/config_files_loader_merger/default.json
@@ -1,0 +1,7 @@
+{
+  "verbose": true,
+  "override_me": "I should be overriden",
+  "deep_merge": {
+    "p1": "v1"
+  }
+}

--- a/spec/fixtures/opt_parse_validator/config_files_loader_merger/enum.yml
+++ b/spec/fixtures/opt_parse_validator/config_files_loader_merger/enum.yml
@@ -1,0 +1,1 @@
+enum: true

--- a/spec/fixtures/opt_parse_validator/config_files_loader_merger/malformed.yml
+++ b/spec/fixtures/opt_parse_validator/config_files_loader_merger/malformed.yml
@@ -1,0 +1,2 @@
+param hello,
+p: 'test'

--- a/spec/fixtures/opt_parse_validator/config_files_loader_merger/override.yml
+++ b/spec/fixtures/opt_parse_validator/config_files_loader_merger/override.yml
@@ -1,0 +1,4 @@
+override_me: "Yeaa"
+deep_merge:
+  p1: v2
+  p2: v3

--- a/spec/fixtures/opt_parse_validator/config_files_loader_merger/regexp_class.yml
+++ b/spec/fixtures/opt_parse_validator/config_files_loader_merger/regexp_class.yml
@@ -1,0 +1,1 @@
+pattern: !ruby/regexp /some (regexp)/i

--- a/spec/fixtures/opt_parse_validator/config_files_loader_merger/result_key.yml
+++ b/spec/fixtures/opt_parse_validator/config_files_loader_merger/result_key.yml
@@ -1,0 +1,3 @@
+cli_options:
+  verbose: false
+  hello: something

--- a/spec/fixtures/opt_parse_validator/config_files_loader_merger/unsupported.ext
+++ b/spec/fixtures/opt_parse_validator/config_files_loader_merger/unsupported.ext
@@ -1,0 +1,1 @@
+Unsupported file format

--- a/spec/fixtures/opt_parse_validator/multi_choices.txt
+++ b/spec/fixtures/opt_parse_validator/multi_choices.txt
@@ -1,0 +1,19 @@
+Available Choices:
+ vp   Vulnerable plugins
+ ap   All plugins
+ p    Plugins
+ vt   Vulnerable themes
+ at   All themes
+ t    Themes Spec
+ tt   Timthumbs
+ dbe  Db exports
+ u    User ids Range, e.g: u1-20, u
+      Range separator to use: '-'
+      Value if no argument supplied: 1-10
+ m    Range separator to use: '-'
+      Value if no argument supplied: 1-100
+Separator to use between the values: ','
+Value if no argument supplied: vp,vt,tt,u,m
+Incompatible choices (only one of each group/s can be used):
+ - ap, vp, p
+ - vt, at, t

--- a/spec/fixtures/opt_parse_validator/multi_choices_w_default.txt
+++ b/spec/fixtures/opt_parse_validator/multi_choices_w_default.txt
@@ -1,0 +1,20 @@
+Available Choices:
+ vp   Vulnerable plugins
+ ap   All plugins
+ p    Plugins
+ vt   Vulnerable themes
+ at   All themes
+ t    Themes Spec
+ tt   Timthumbs
+ dbe  Db exports
+ u    User ids Range, e.g: u1-20, u
+      Range separator to use: '-'
+      Value if no argument supplied: 1-10
+ m    Range separator to use: '-'
+      Value if no argument supplied: 1-100
+Separator to use between the values: ','
+Default: All Plugins, Users: 1..5
+Value if no argument supplied: vp,vt,tt,u,m
+Incompatible choices (only one of each group/s can be used):
+ - ap, vp, p
+ - vt, at, t

--- a/spec/fixtures/opt_parse_validator/smart_list.txt
+++ b/spec/fixtures/opt_parse_validator/smart_list.txt
@@ -1,0 +1,3 @@
+aaa
+bb
+ccc

--- a/spec/lib/opt_parse_validator/config_files_loader_merger/base_spec.rb
+++ b/spec/lib/opt_parse_validator/config_files_loader_merger/base_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::ConfigFilesLoaderMerger::ConfigFile::Base do
+  subject(:file) { described_class.new('test') }
+
+  describe '#parse' do
+    it 'raises an error' do
+      expect { file.parse }.to raise_error NotImplementedError
+    end
+  end
+
+  describe '#==' do
+    # Handled in options_files_spec.rb#<<
+  end
+end

--- a/spec/lib/opt_parse_validator/config_files_loader_merger/json_spec.rb
+++ b/spec/lib/opt_parse_validator/config_files_loader_merger/json_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::ConfigFilesLoaderMerger::ConfigFile::JSON do
+  subject(:file) { described_class.new(fixtures.join(fixture)) }
+  let(:fixtures) { OPV_FIXTURES.join('config_files_loader_merger') }
+
+  describe '#parse' do
+    # Handled in options_files_spec.rb#parse
+  end
+end

--- a/spec/lib/opt_parse_validator/config_files_loader_merger/yml_spec.rb
+++ b/spec/lib/opt_parse_validator/config_files_loader_merger/yml_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::ConfigFilesLoaderMerger::ConfigFile::YML do
+  subject(:file) { described_class.new(fixtures.join(fixture)) }
+  let(:fixtures) { OPV_FIXTURES.join('config_files_loader_merger') }
+
+  describe '#parse' do
+    # Handled in options_files_spec.rb#parse
+
+    context 'when the file is empty' do
+      let(:fixture) { 'empty_file' }
+
+      its(:parse) { should eql({}) }
+    end
+
+    context 'when file contains a non whitelisted class' do
+      let(:fixture) { 'date_class.yml' }
+
+      it 'raises an error' do
+        expect { file.parse }.to raise_error(Psych::DisallowedClass)
+      end
+    end
+
+    context 'when file contains a whitelisted class (regexp)' do
+      let(:fixture) { 'regexp_class.yml' }
+
+      its(:parse) { should eql('pattern' => /some (regexp)/i) }
+    end
+  end
+end

--- a/spec/lib/opt_parse_validator/config_files_loader_merger_spec.rb
+++ b/spec/lib/opt_parse_validator/config_files_loader_merger_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::ConfigFilesLoaderMerger do
+  subject(:files)     { described_class.new }
+  let(:fixtures)      { OPV_FIXTURES.join('config_files_loader_merger') }
+  let(:default_file)  { fixtures.join('default.json') }
+  let(:override_file) { fixtures.join('override.yml') }
+
+  describe '#supported_extensions' do
+    its(:supported_extensions) { %w[json yml] }
+  end
+
+  describe '#result_key' do
+    its(:result_key) { should be_nil }
+  end
+
+  describe '#<<' do
+    context 'when the file does not exist' do
+      it 'returns self' do
+        expect(files << 'not-there.json').to eql files
+      end
+    end
+
+    context 'when the format is not supported' do
+      it 'raises an error' do
+        expect { files << fixtures.join('unsupported.ext') }
+          .to raise_error(
+            OptParseValidator::Error,
+            "The option file's extension 'ext' is not supported"
+          )
+      end
+    end
+
+    context 'when the format is supported' do
+      it 'adds the file' do
+        files << default_file << override_file
+
+        expect(files).to eq [
+          OptParseValidator::ConfigFilesLoaderMerger::ConfigFile::JSON.new(default_file),
+          OptParseValidator::ConfigFilesLoaderMerger::ConfigFile::YML.new(override_file)
+        ]
+      end
+    end
+  end
+
+  describe '#parse' do
+    before { files << default_file << override_file }
+
+    let(:expected_hash) do
+      {
+        verbose: true, override_me: 'Yeaa',
+        deep_merge: { p1: 'v2', p2: 'v3' }
+      }
+    end
+
+    its(:parse) { should eql(expected_hash) }
+
+    context 'when YAML class contains a regexp' do
+      before { files << fixtures.join('regexp_class.yml') }
+
+      its(:parse) { should include(pattern: /some (regexp)/i) }
+    end
+
+    context 'when result_key set' do
+      before { files.result_key = 'cli_options' }
+
+      context 'when result_key not in the results' do
+        its(:parse) { should eql({}) }
+      end
+
+      context 'when result_key in the results' do
+        before { files << fixtures.join('result_key.yml') }
+
+        its(:parse) { should eql(verbose: false, hello: 'something') }
+      end
+    end
+  end
+end

--- a/spec/lib/opt_parse_validator/opts/alias_spec.rb
+++ b/spec/lib/opt_parse_validator/opts/alias_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::OptAlias do
+  subject(:opt) { described_class.new(option, attrs) }
+  let(:option)  { %w[-a --alias] }
+  let(:attrs)   { { alias_for: '--test -e' } }
+
+  describe '#initialise, #alias_for' do
+    context 'when no :alias_for attrs' do
+      let(:attrs) { {} }
+
+      it 'raises an error' do
+        expect { opt }.to raise_error 'The :alias_for attribute is required'
+      end
+    end
+
+    context 'when :alias_for attrs' do
+      it 'sets it' do
+        expect(opt.alias_for).to eql attrs[:alias_for]
+      end
+    end
+  end
+
+  describe '#alias?' do
+    its(:alias?) { should be true }
+  end
+
+  describe '#help_messages' do
+    it 'contains the message related to the alias' do
+      expect(opt.help_messages).to include("Alias for #{attrs[:alias_for]}")
+    end
+  end
+end

--- a/spec/lib/opt_parse_validator/opts/array_spec.rb
+++ b/spec/lib/opt_parse_validator/opts/array_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::OptArray do
+  subject(:opt) { described_class.new(['-a', '--array VALUES'], attrs) }
+  let(:attrs)   { {} }
+
+  describe '#append_help_messages' do
+    context 'when default separator' do
+      its(:help_messages) { should eql ["Separator to use between the values: ','"] }
+    end
+
+    context 'when custom separator' do
+      let(:attrs) { super().merge(separator: '-') }
+
+      its(:help_messages) { should eql ["Separator to use between the values: '-'"] }
+    end
+  end
+
+  describe '#validate' do
+    context 'when an empty or nil value is given' do
+      context 'when no value_if_empty attribute' do
+        it 'raises an error' do
+          [nil, ''].each do |value|
+            expect { opt.validate(value) }.to raise_error(OptParseValidator::Error, 'Empty option value supplied')
+          end
+        end
+      end
+
+      context 'when value_if_empty attribute' do
+        let(:attrs) { super().merge(value_if_empty: 'a,b') }
+
+        it 'returns the expected array' do
+          [nil, ''].each do |value|
+            expect(opt.validate(value)).to eql %w[a b]
+          end
+        end
+      end
+    end
+
+    context 'when the separator is not supplied' do
+      context 'when not present in the argument' do
+        it 'returns an array with the correct value' do
+          expect(opt.validate('rspec')).to eql %w[rspec]
+        end
+      end
+
+      context 'when present' do
+        it 'returns the expected array' do
+          expect(opt.validate('r1,r2,r3')).to eql %w[r1 r2 r3]
+        end
+      end
+    end
+
+    context 'when separator supplied' do
+      subject(:opt) { described_class.new(['-a', '--array VALUES'], separator: '-') }
+
+      it 'returns an array with the correct value' do
+        expect(opt.validate('r1,r2,r3')).to eql %w[r1,r2,r3]
+      end
+
+      it 'returns the expected array' do
+        expect(opt.validate('r1-r2-r3')).to eql %w[r1 r2 r3]
+      end
+    end
+  end
+
+  describe '#normalize' do
+    after { expect(opt.normalize(@value)).to eql @expected }
+
+    context 'when no :normalize attribute' do
+      it 'returns the value' do
+        @value    = %w[t1 t2]
+        @expected = @value
+      end
+    end
+
+    context 'when a single normalization' do
+      let(:attrs) { { normalize: :to_sym } }
+
+      it 'returns the expected value' do
+        @value    = [1.0, 'test']
+        @expected = [1.0, :test]
+      end
+    end
+  end
+end

--- a/spec/lib/opt_parse_validator/opts/base_spec.rb
+++ b/spec/lib/opt_parse_validator/opts/base_spec.rb
@@ -1,0 +1,265 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::OptBase do
+  subject(:opt) { described_class.new(option, attrs) }
+  let(:option)  { %w[-v --verbose] }
+  let(:attrs)   { {} }
+
+  describe '#help_messages, #append_help_messages' do
+    context 'when no messages from the option argument' do
+      context 'when no default attribute' do
+        its(:help_messages) { should eql([]) }
+      end
+
+      context 'when :default attribute' do
+        let(:attrs) { { default: 'test' } }
+
+        its(:help_messages) { should eql ['Default: test'] }
+      end
+
+      context 'when :value_if_empty attribute' do
+        let(:attrs) { { value_if_empty: 'aa' } }
+
+        its(:help_messages) { should eql ['Value if no argument supplied: aa'] }
+      end
+
+      context 'when :required attribute' do
+        let(:attrs) { { required: true } }
+
+        its(:help_messages) { should eql ['This option is mandatory'] }
+      end
+
+      context 'when :required_unless attribute' do
+        context 'when a signle required_unless value' do
+          let(:attrs) { { required_unless: :hh } }
+
+          its(:help_messages) { should eql ['This option is mandatory unless hh is/are supplied'] }
+        end
+
+        context 'when multiple required_unless values' do
+          let(:attrs) { { required_unless: %i[hh bb] } }
+
+          its(:help_messages) { should eql ['This option is mandatory unless hh or bb is/are supplied'] }
+        end
+      end
+
+      context 'when multiple attributes' do
+        let(:attrs) { { value_if_empty: 'aa', required_unless: :hh } }
+
+        its(:help_messages) do
+          should eql ['Value if no argument supplied: aa',
+                      'This option is mandatory unless hh is/are supplied']
+        end
+      end
+    end
+
+    context 'when messages' do
+      let(:option) { super() << 'Verbose Mode' << 'Another message' }
+
+      context 'when on default attribute' do
+        its(:help_messages) { should eql option[2..3] }
+      end
+
+      context 'when default attribute' do
+        let(:attrs) { { default: 'test' } }
+
+        its(:help_messages) { should eql option[2..3] << 'Default: test' }
+      end
+    end
+  end
+
+  describe '#to_long' do
+    after { expect(described_class.new(@option).to_long).to eql @expected }
+
+    context 'when not found' do
+      it 'returns nil' do
+        @option = %w[-v]
+        @expected = nil
+      end
+    end
+
+    context 'when found' do
+      it 'returns the long name' do
+        @option = ['-v', '--[no-]verbose VALUE [OPT]', 'Verbose Mode']
+        @expected = '--verbose'
+      end
+    end
+  end
+
+  describe '#to_sym' do
+    after :each do
+      if @exception
+        expect { described_class.new(@option).to_sym }.to raise_error(*@exception)
+      else
+        expect(described_class.new(@option).to_sym).to eql(@expected)
+      end
+    end
+
+    context 'without REQUIRED or OPTIONAL arguments' do
+      context 'with short option' do
+        it 'returns :test' do
+          @option   = %w[-t --test Testing]
+          @expected = :test
+        end
+
+        it 'returns :its_a_long_option' do
+          @option   = ['-l', '--its-a-long-option', "Testing '-' replacement"]
+          @expected = :its_a_long_option
+        end
+      end
+
+      context 'without short option' do
+        it 'returns :long' do
+          @option   = ['--long']
+          @expected = :long
+        end
+
+        it 'returns :long_option' do
+          @option   = ['--long-option', 'No short !']
+          @expected = :long_option
+        end
+      end
+
+      context 'without long option' do
+        it 'raises an error' do
+          @option    = ['-v', 'long option missing']
+          @exception = OptParseValidator::Error, 'Could not find option symbol for ["-v", "long option missing"]'
+        end
+
+        it 'raises an error' do
+          @option    = ['long option missing']
+          @exception = OptParseValidator::Error, 'Could not find option symbol for ["long option missing"]'
+        end
+      end
+
+      context 'with multiple long option names (like alias)' do
+        it 'returns the first long option found' do
+          @option   = %w[--check-long --cl]
+          @expected = :check_long
+        end
+      end
+    end
+
+    context 'when negative prefix name' do
+      it 'returns the positive option symbol' do
+        @option   = %w(-v --[no-]verbose)
+        @expected = :verbose
+      end
+    end
+
+    context 'with REQUIRED or OPTIONAL arguments' do
+      it 'should removed the OPTIONAL argument' do
+        @option   = ['-p', '--page [PAGE_NUMBER]']
+        @expected = :page
+      end
+
+      it 'should removed the REQUIRED argument' do
+        @option   = ['--url TARGET_URL']
+        @expected = :url
+      end
+    end
+  end
+
+  describe '#new, #required?' do
+    context 'when no :required' do
+      its(:option)    { should eq(option) }
+      its(:required?) { should be_falsey }
+      its(:to_sym)    { should eq(:verbose) }
+    end
+
+    context 'when :required' do
+      let(:attrs) { { required: true } }
+
+      its(:required?) { should be true }
+    end
+  end
+
+  describe '#alias?' do
+    its(:alias?) { should be false }
+  end
+
+  describe '#advanced?' do
+    its(:advanced?) { should be false }
+
+    context 'when :advanced' do
+      let(:attrs) { { advanced: true } }
+
+      its(:advanced?) { should be true }
+    end
+  end
+
+  describe '#normalize' do
+    after { expect(opt.normalize(@value)).to eql @expected }
+
+    context 'when no :normalize attribute' do
+      it 'returns the value' do
+        @value    = 'test'
+        @expected = @value
+      end
+    end
+
+    context 'when a single normalization' do
+      let(:attrs) { { normalize: :to_sym } }
+
+      context 'when the value does not have a to_sym method' do
+        it 'returns the value' do
+          @value    = 1.0
+          @expected = @value
+        end
+      end
+
+      context 'when a to_sym method' do
+        it 'returns the symbol' do
+          @value    = 'test'
+          @expected = :test
+        end
+      end
+    end
+
+    context 'when multiple normalization' do
+      let(:attrs) { { normalize: [:to_sym, 2.0, :upcase] } }
+
+      it 'apply each of them (if possible)' do
+        @value    = 'test'
+        @expected = :TEST
+      end
+    end
+  end
+
+  describe '#validate' do
+    context 'when no value_if_empty attribute' do
+      context 'when an empty or nil value' do
+        it 'raises an error' do
+          [nil, ''].each do |value|
+            expect { opt.validate(value) }
+              .to raise_error(OptParseValidator::Error, 'Empty option value supplied')
+          end
+        end
+      end
+
+      context 'when a valid value' do
+        it 'returns it' do
+          expect(opt.validate('testing')).to eql 'testing'
+        end
+      end
+    end
+
+    context 'when value_if_empty attribute' do
+      let(:attrs) { super().merge(value_if_empty: 'it works') }
+
+      context 'when nil or empty value' do
+        it 'returns the value from the value_if_empty attribute' do
+          [nil, ''].each do |value|
+            expect(opt.validate(value)).to eql attrs[:value_if_empty]
+          end
+        end
+      end
+
+      context 'when a valid value' do
+        it 'returns it' do
+          expect(opt.validate('tt')).to eql 'tt'
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/opt_parse_validator/opts/boolean_spec.rb
+++ b/spec/lib/opt_parse_validator/opts/boolean_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::OptBoolean do
+  subject(:opt) { described_class.new(['-b', '--bool BOOL']) }
+
+  describe '#validate' do
+    context 'when does not match TRUE_PATTERN and FALSE_PATTERN' do
+      it 'raises an error' do
+        expect { opt.validate("true\nfalse") }
+          .to raise_error(OptParseValidator::Error, 'Invalid boolean value, expected true|t|yes|y|1|false|f|no|n|0')
+      end
+    end
+
+    context 'when matches TRUE_PATTERN' do
+      after { expect(opt.validate(@argument)).to be true }
+
+      %w[true t yes y 1].each do |arg|
+        it 'returns true' do
+          @argument = arg
+        end
+      end
+    end
+
+    context 'when matches FALSE_PATTERN' do
+      after { expect(opt.validate(@argument)).to be false }
+
+      %w[false f no n 0].each do |arg|
+        it 'returns false' do
+          @argument = arg
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/opt_parse_validator/opts/choice_spec.rb
+++ b/spec/lib/opt_parse_validator/opts/choice_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::OptChoice do
+  subject(:opt) { described_class.new(option, attrs) }
+  let(:option)  { ['-f', '--format FORMAT'] }
+  let(:attrs)   { { choices: %w[json cli] } }
+
+  describe '#new' do
+    context 'when errors' do
+      after { expect { opt }.to raise_error(*@exception) }
+
+      context 'when :choices not provided' do
+        let(:attrs) { {} }
+
+        it 'raises an error' do
+          @exception = OptParseValidator::Error, 'The :choices attribute is mandatory'
+        end
+      end
+
+      context 'when :choices is not an array' do
+        let(:attrs) { { choices: 'wrong type' } }
+
+        it 'raises an error' do
+          @exception = OptParseValidator::Error, 'The :choices attribute must be an array'
+        end
+      end
+    end
+
+    context 'when valid' do
+      it 'sets the option correctly' do
+        expect { opt }.to_not raise_error
+        expect(opt.attrs[:choices]).to eq attrs[:choices]
+      end
+    end
+  end
+
+  describe '#append_help_messages' do
+    context 'when no default attribute' do
+      its(:help_messages) { should eql ["Available choices: #{attrs[:choices].join(', ')}"] }
+    end
+
+    context 'when a default attribute' do
+      let(:attrs) { super().merge(default: 'cli') }
+
+      its(:help_messages) { should eql ['Default: cli', 'Available choices: json, cli'] }
+
+      context 'when the default is not given as a string' do
+        let(:attrs) { super().merge(normalize: :to_sym, default: :json) }
+
+        its(:help_messages) { should eql ['Default: json', 'Available choices: json, cli'] }
+      end
+    end
+  end
+
+  describe '#validate' do
+    after :each do
+      if @exception
+        expect { opt.validate(@value) }.to raise_error(*@exception)
+      else
+        expect(opt.validate(@value)).to eq(@expected)
+      end
+    end
+
+    context 'when the value is not in the choices' do
+      it 'raises an error' do
+        @value     = 'invalid-format'
+        @exception = OptParseValidator::Error,
+                     "'invalid-format' is not a valid choice, expected one of the followings: json,cli"
+      end
+
+      context 'when :case_sensitive' do
+        let(:attrs) { { choices: %w[json cli], case_sensitive: true } }
+
+        it 'raises an error' do
+          @value     = 'JSON'
+          @exception = OptParseValidator::Error,
+                       "'JSON' is not a valid choice, expected one of the followings: json,cli"
+        end
+      end
+    end
+
+    context 'when valid choice' do
+      it 'returns the choice' do
+        @value    = 'JSON'
+        @expected = 'json'
+      end
+
+      context 'when :case_sensitive' do
+        let(:attrs) { { choices: %w[JSON cli], case_sensitive: true } }
+
+        it 'raises an error' do
+          @value    = 'JSON'
+          @expected = 'JSON'
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/opt_parse_validator/opts/credentials_spec.rb
+++ b/spec/lib/opt_parse_validator/opts/credentials_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::OptCredentials do
+  subject(:opt) { described_class.new(['-l', '--login USERNAME:PASSWORD']) }
+
+  describe '#validate' do
+    context 'when incorrect format' do
+      it 'raises an error' do
+        expect { opt.validate('wrong') }
+          .to raise_error(OptParseValidator::Error, 'Incorrect credentials format, username:password expected')
+      end
+    end
+
+    context 'when valid format' do
+      it 'returns a hash with :username and :password' do
+        expect(opt.validate('admin:P@ssw:rd'))
+          .to eq(username: 'admin', password: 'P@ssw:rd')
+      end
+    end
+  end
+end

--- a/spec/lib/opt_parse_validator/opts/direcyory_path_spec.rb
+++ b/spec/lib/opt_parse_validator/opts/direcyory_path_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::OptDirectoryPath do
+  subject(:opt)  { described_class.new(['-d', '--dir DIR'], attrs) }
+  let(:attrs)    { {} }
+  let(:dir_path) { OPV_FIXTURES.join('advanced_help').to_s }
+
+  its(:attrs) { should eq directory: true }
+
+  describe '#validate' do
+    context 'when it is a directory' do
+      it 'returns the path' do
+        expect(opt.validate(dir_path)).to eql dir_path
+      end
+    end
+
+    context 'when it\'s not ' do
+      it 'raises an error' do
+        expect { opt.validate('yolo.txt') }.to raise_error "The path 'yolo.txt' does not exist or is not a directory"
+      end
+    end
+
+    context 'when the directory does not exist' do
+      let(:dir_path) { OPV_FIXTURES.join('aaa') }
+
+      it 'raises an error' do
+        expect { opt.validate(dir_path) }.to raise_error "The path '#{dir_path}' does not exist or is not a directory"
+      end
+    end
+
+    context 'when :create' do
+      let(:attrs) { { create: true } }
+      let(:dir_path) { OPV_FIXTURES.join('dir_path').to_s }
+
+      it 'creates it' do
+        expect(opt.validate(dir_path)).to eql dir_path
+        expect(Dir.exist?(dir_path)).to eql true
+
+        FileUtils.remove_dir(dir_path)
+      end
+    end
+  end
+end

--- a/spec/lib/opt_parse_validator/opts/file_path_spec.rb
+++ b/spec/lib/opt_parse_validator/opts/file_path_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::OptFilePath do
+  subject(:opt)   { described_class.new(['-f', '--file FILE_PATH'], attrs) }
+  let(:attrs)     { {} }
+  let(:file_path) { OPV_FIXTURES.join('file_path.txt').to_s }
+
+  its(:attrs)     { should eq file: true }
+
+  describe '#validate' do
+    context 'when the path does not exist' do
+      let(:file_path) { OPV_FIXTURES.join('aaa.txt') }
+
+      it 'raises an error' do
+        expect { opt.validate(file_path) }
+          .to raise_error(OptParseValidator::Error, "The path '#{file_path}' does not exist or is not a file")
+      end
+    end
+
+    context 'when the path is a directory' do
+      let(:file_path) { OPV_FIXTURES.to_s }
+
+      it 'raises an error' do
+        expect { opt.validate(file_path) }
+          .to raise_error(OptParseValidator::Error, "The path '#{file_path}' does not exist or is not a file")
+      end
+    end
+
+    context 'when :extensions' do
+      let(:attrs) { { extensions: 'txt' } }
+
+      its('allowed_attrs.first') { should eq :extensions }
+
+      context 'when it matches' do
+        it 'returns the path' do
+          expect(opt.validate(file_path)).to eql file_path
+        end
+      end
+
+      context 'when it does no match' do
+        it 'raises an error' do
+          expect { opt.validate('yolo.aa') }
+            .to raise_error(OptParseValidator::Error, "The extension of 'yolo.aa' is not allowed")
+        end
+      end
+    end
+
+    context 'when :create' do
+      let(:attrs) { { create: true } }
+
+      context 'when the file exists' do
+        it 'does not create it' do
+          expect(FileUtils).to_not receive(:touch)
+
+          expect(opt.validate(file_path)).to eql file_path
+        end
+      end
+
+      context 'when the file does not exist' do
+        let(:file_path) { OPV_FIXTURES.join('file_path2.txt').to_s }
+
+        it 'creates it' do
+          expect(opt.validate(file_path)).to eql file_path
+          expect(File.exist?(file_path)).to eql true
+
+          FileUtils.remove_file(file_path)
+        end
+      end
+    end
+
+    context 'when :executable' do
+      let(:attrs) { { executable: true } }
+
+      it 'returns the path if executable' do
+        expect_any_instance_of(Pathname).to receive(:executable?).and_return(true)
+
+        expect(opt.validate(file_path)).to eql file_path
+      end
+
+      it 'raises an error if not ' do
+        expect do
+          opt.validate(file_path)
+        end.to raise_error(OptParseValidator::Error, "The path '#{file_path}' is not executable")
+      end
+    end
+
+    context 'when :readable' do
+      let(:attrs) { { readable: true, exists: false } }
+
+      it 'returns the path if readable' do
+        expect(opt.validate(file_path)).to eql file_path
+      end
+
+      it 'raises an error otherwise' do
+        expect_any_instance_of(Pathname).to receive(:readable?).and_return(false)
+
+        expect do
+          opt.validate(file_path)
+        end.to raise_error(OptParseValidator::Error, "The path '#{file_path}' is not readable")
+      end
+    end
+
+    context 'when :writable' do
+      context 'when the path exists' do
+        let(:attrs) { { writable: true } }
+
+        it 'returns the path if writable' do
+          expect(opt.validate(file_path)).to eql file_path
+        end
+
+        it 'raises an error otherwise' do
+          expect_any_instance_of(Pathname).to receive(:writable?).and_return(false)
+
+          expect do
+            opt.validate(file_path)
+          end.to raise_error(OptParseValidator::Error, "The path '#{file_path}' is not writable")
+        end
+      end
+
+      context 'when it does not exist' do
+        let(:attrs) { { writable: true, exists: false } }
+
+        context 'when the parent directory is writable' do
+          let(:file) { OPV_FIXTURES.join('advanced_help', 'not_there.txt').to_s }
+
+          it 'returns the path' do
+            expect(opt.validate(file)).to eql file
+          end
+        end
+
+        context 'when the parent directory is not writable' do
+          let(:file) { OPV_FIXTURES.join('hfjhg', 'yolo.rb').to_s }
+
+          it 'raises an error' do
+            expect { opt.validate(file) }.to raise_error(OptParseValidator::Error, "The path '#{file}' is not writable")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/opt_parse_validator/opts/headers_spec.rb
+++ b/spec/lib/opt_parse_validator/opts/headers_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::OptHeaders do
+  subject(:opt) { described_class.new(['--headers H'], attrs) }
+  let(:attrs)   { {} }
+
+  describe '#append_help_messages' do
+    its(:help_messages) do
+      should eql [
+        "Separator to use between the headers: '; '",
+        "Examples: 'X-Forwarded-For: 127.0.0.1', 'X-Forwarded-For: 127.0.0.1; Another: aaa'"
+      ]
+    end
+  end
+
+  describe '#validates' do
+    context 'when malformed' do
+      it 'raises an error' do
+        ['Test', 'Test aa;', 'V: aa; Test'].each do |value|
+          expect { opt.validate(value) }.to raise_error(OptParseValidator::Error)
+        end
+      end
+    end
+
+    context 'when valid' do
+      context 'when basic headers' do
+        it 'returns the expected hash' do
+          expect(opt.validate('Test: aa')).to eql('Test' => 'aa')
+          expect(opt.validate('Test: aa;')).to eql('Test' => 'aa')
+          expect(opt.validate('T: aa; V: bb')).to eql('T' => 'aa', 'V' => 'bb')
+          expect(opt.validate('T: aa; V:;')).to eql('T' => 'aa', 'V' => '')
+        end
+      end
+
+      context 'when header content contains a : or ;' do
+        it 'returns the expected hash' do
+          expect(opt.validate('Referer: http://test.com')).to eql('Referer' => 'http://test.com')
+          expect(opt.validate('Accept-Language: en-GB,en;q=0.5')).to eql('Accept-Language' => 'en-GB,en;q=0.5')
+          expect(opt.validate('A-L: en-GB;q=0.5; R: http://t.com')).to eql('A-L' => 'en-GB;q=0.5', 'R' => 'http://t.com')
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/opt_parse_validator/opts/integer_range_spec.rb
+++ b/spec/lib/opt_parse_validator/opts/integer_range_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::OptIntegerRange do
+  subject(:opt) { described_class.new(['--range RANGE'], attrs) }
+  let(:attrs)   { {} }
+
+  describe '#append_help_messages' do
+    context 'when no value_if_empty attribute' do
+      its(:help_messages) { should eql ["Range separator to use: '-'"] }
+    end
+
+    context 'when value_if_empty attribute' do
+      let(:attrs) { super().merge(value_if_empty: '1-10') }
+
+      its(:help_messages) do
+        should eql [
+          "Range separator to use: '-'",
+          'Value if no argument supplied: 1-10'
+        ]
+      end
+    end
+  end
+
+  describe '#validate' do
+    context 'when incorrect number of ranges given' do
+      it 'raises an error' do
+        expect { opt.validate('1-2-3') }
+          .to raise_error(OptParseValidator::Error, 'Incorrect number of ranges found: 3, should be 2')
+      end
+    end
+
+    context 'when not an integer range' do
+      it 'raises an error' do
+        expect { opt.validate('a-e') }
+          .to raise_error(OptParseValidator::Error, 'Argument is not a valid integer range')
+      end
+    end
+
+    context 'when a valid range' do
+      it 'returns the range' do
+        expect(opt.validate('1-5')).to eql(1..5)
+      end
+
+      context 'when another separator' do
+        let(:attrs) { super().merge(separator: ':') }
+
+        it 'returns the range' do
+          expect(opt.validate('0:10')).to eql(0..10)
+        end
+      end
+    end
+
+    context 'when nil or "" supplied' do
+      context 'when no value_if_empty attribute' do
+        it 'raises an error' do
+          [nil, ''].each do |value|
+            expect { opt.validate(value) }.to raise_error(OptParseValidator::Error, 'Empty option value supplied')
+          end
+        end
+      end
+
+      context 'when value_if_empty attribute' do
+        let(:attrs) { super().merge(value_if_empty: '0-2') }
+
+        it 'returns the value_if_empty value' do
+          [nil, ''].each do |value|
+            expect(opt.validate(value)).to eql(0..2)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/opt_parse_validator/opts/integer_spec.rb
+++ b/spec/lib/opt_parse_validator/opts/integer_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::OptInteger do
+  subject(:opt) { described_class.new(['-i', '--int INT']) }
+
+  describe '#validate' do
+    context 'when not an integer' do
+      it 'raises an error' do
+        expect { opt.validate('a') }.to raise_error(OptParseValidator::Error, 'a is not an integer')
+      end
+    end
+
+    it 'returns the integer' do
+      expect(opt.validate('12')).to eq 12
+    end
+  end
+end

--- a/spec/lib/opt_parse_validator/opts/multi_choices_spec.rb
+++ b/spec/lib/opt_parse_validator/opts/multi_choices_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::OptMultiChoices do
+  subject(:opt) { described_class.new(['--enumerate [CHOICES]'], attrs) }
+  let(:attrs) do
+    {
+      choices: {
+        vp: OptParseValidator::OptBoolean.new(['--vulnerable-plugins']),
+        ap: OptParseValidator::OptBoolean.new(['--all-plugins']),
+        p: OptParseValidator::OptBoolean.new(['--plugins']),
+        vt: OptParseValidator::OptBoolean.new(['--vulnerable-themes']),
+        at: OptParseValidator::OptBoolean.new(['--all-themes']),
+        t: OptParseValidator::OptBoolean.new(['--themes', 'Themes Spec']),
+        tt: OptParseValidator::OptBoolean.new(['--timthumbs']),
+        dbe: OptParseValidator::OptBoolean.new(['--db-exports']),
+        u: OptParseValidator::OptIntegerRange.new(['--users', 'User ids Range, e.g: u1-20, u'], value_if_empty: '1-10'),
+        m: OptParseValidator::OptIntegerRange.new(['--media'], value_if_empty: '1-100')
+      },
+      incompatible: [%i[ap vp p], %i[vt at t]]
+    }
+  end
+
+  describe '#new' do
+    context 'when no choices attribute' do
+      let(:attrs) { {} }
+
+      it 'raises an error' do
+        expect { opt }.to raise_error(OptParseValidator::Error, 'The :choices attribute is mandatory')
+      end
+    end
+
+    context 'when choices attribute' do
+      context 'when not a hash' do
+        let(:attrs) { { choices: 'invalid' } }
+
+        it 'raises an error' do
+          expect { opt }.to raise_error(OptParseValidator::Error, 'The :choices attribute must be a hash')
+        end
+      end
+
+      context 'when a hash' do
+        it 'does not raise any error' do
+          expect { opt }.to_not raise_error
+        end
+      end
+    end
+  end
+
+  describe '#append_help_messages' do
+    let(:attrs) { super().merge(value_if_empty: 'vp,vt,tt,u,m') }
+
+    its(:help_messages) { should match_array File.readlines(OPV_FIXTURES.join('multi_choices.txt')).map(&:chomp) }
+
+    context 'when default' do
+      let(:attrs) { super().merge(default: { all_plugins: true, users: (1..5) }) }
+
+      its(:help_messages) do
+        should match_array File.readlines(OPV_FIXTURES.join('multi_choices_w_default.txt')).map(&:chomp)
+      end
+    end
+  end
+
+  describe '#validate' do
+    context 'when an unknown choice is given' do
+      it 'raises an error' do
+        expect { opt.validate('vp,n') }.to raise_error(OptParseValidator::Error, 'Unknown choice: n')
+      end
+    end
+
+    context 'when nil or empty value' do
+      context 'when no value_if_empty attribute' do
+        it 'raises an error' do
+          [nil, ''].each do |value|
+            expect { opt.validate(value) }.to raise_error(OptParseValidator::Error, 'Empty option value supplied')
+          end
+        end
+      end
+
+      context 'when value_if_empty attribute' do
+        let(:attrs) { super().merge(value_if_empty: 'vp,u') }
+
+        it 'returns the expected hash' do
+          [nil, ''].each do |value|
+            expect(opt.validate(value)).to eql(vulnerable_plugins: true, users: (1..10))
+          end
+        end
+      end
+    end
+
+    context 'when value' do
+      it 'returns the expected hash' do
+        expect(opt.validate('u2-5')).to eql(users: (2..5))
+      end
+
+      context 'when incompatible choices given' do
+        it 'raises an error' do
+          {
+            'ap,p,t' => 'ap, p',
+            'ap,t,vp' => 'ap, vp',
+            'ap,at,t' => 'at, t'
+          }.each do |value, msg|
+            expect do
+              opt.validate(value)
+            end.to raise_error(OptParseValidator::Error, "Incompatible choices detected: #{msg}")
+          end
+        end
+      end
+    end
+  end
+
+  describe '#normalize' do
+    it 'returns the same value (no normalization)' do
+      expect(opt.normalize('a')).to eql 'a'
+    end
+  end
+end

--- a/spec/lib/opt_parse_validator/opts/path_spec.rb
+++ b/spec/lib/opt_parse_validator/opts/path_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::OptPath do
+  # Everything is handled in OptFilePath & OptDirectoryPath
+end

--- a/spec/lib/opt_parse_validator/opts/positive_integer_spec.rb
+++ b/spec/lib/opt_parse_validator/opts/positive_integer_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::OptPositiveInteger do
+  subject(:opt) { described_class.new(['-i', '--int INT']) }
+
+  describe '#validate' do
+    context 'when not > 0' do
+      it 'raises an error' do
+        expect { opt.validate('-3') }.to raise_error(OptParseValidator::Error, '-3 is not > 0')
+      end
+    end
+
+    it 'returns the integer' do
+      expect(opt.validate('20')).to eq 20
+    end
+  end
+end

--- a/spec/lib/opt_parse_validator/opts/proxy_spec.rb
+++ b/spec/lib/opt_parse_validator/opts/proxy_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::OptProxy do
+  subject(:opt) { described_class.new(['--proxy PROXY'], attrs) }
+  let(:attrs)   { { protocols: %w[http https socks socks5 socks4] } }
+
+  describe '#validate' do
+    # Handled by OptURI
+  end
+end

--- a/spec/lib/opt_parse_validator/opts/regexp_spec.rb
+++ b/spec/lib/opt_parse_validator/opts/regexp_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::OptRegexp do
+  subject(:opt) { described_class.new(['-r', '--regexp STRING'], attrs) }
+  let(:attrs)   { {} }
+
+  describe '#validate' do
+    context 'when an empty value' do
+      it 'raises an error' do
+        expect { opt.validate('') }.to raise_error(OptParseValidator::Error, 'Empty option value supplied')
+      end
+    end
+
+    context 'when no options' do
+      it 'returns a Regexp' do
+        expect(opt.validate('some text')).to eql(/some text/)
+      end
+    end
+
+    context 'when options' do
+      let(:attrs) { { options: Regexp::IGNORECASE | Regexp::MULTILINE } }
+
+      it 'returns the expected Regexp' do
+        expect(opt.validate('text')).to eql(/text/im)
+      end
+    end
+  end
+end

--- a/spec/lib/opt_parse_validator/opts/smart_list_spec.rb
+++ b/spec/lib/opt_parse_validator/opts/smart_list_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::OptSmartList do
+  subject(:opt) { described_class.new(['-l', '--list ARG'], attrs) }
+  let(:attrs)   { {} }
+
+  describe '#append_help_messages' do
+    let(:expected) { ["Examples: 'a1', '#{%w[a1 a2 a3].join(opt.separator)}', '/tmp/a.txt'"] }
+
+    context 'when no attributes' do
+      its(:help_messages) { should eql expected }
+    end
+
+    context 'when :default attribute' do
+      let(:attrs) { super().merge(default: 'bb') }
+
+      its(:help_messages) { should eql ['Default: bb'] + expected }
+    end
+  end
+
+  describe '#validate' do
+    context 'when just a word' do
+      it 'returns the expected array' do
+        expect(opt.validate('aa')).to eql %w[aa]
+      end
+    end
+
+    context 'when multiple words separated' do
+      context 'with the correct separator' do
+        it 'returns the expected array' do
+          expect(opt.validate('aa,bb,cc')).to eql %w[aa bb cc]
+        end
+      end
+
+      context 'with the wrong separator' do
+        it 'is assumed as a word' do
+          expect(opt.validate('aa:bb')).to eql %w[aa:bb]
+        end
+      end
+    end
+
+    context 'when a file path' do
+      let(:path) { OPV_FIXTURES.join('smart_list.txt') }
+
+      context 'when the file exists and is readable' do
+        it 'returns the correct array' do
+          expect(opt.validate(path)).to eql %w[aaa bb ccc]
+        end
+      end
+
+      context 'when the file exists but is not readable' do
+        it 'raises an error' do
+          allow(File).to receive(:open).and_raise(Errno::EACCES)
+
+          expect { opt.validate(path) }.to raise_error Errno::EACCES
+        end
+      end
+
+      context 'when the file does not exist' do
+        let(:path) { "#{super()}.aa" }
+
+        it 'is assumed as a word' do
+          expect(opt.validate(path)).to eql [path]
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/opt_parse_validator/opts/uri_spec.rb
+++ b/spec/lib/opt_parse_validator/opts/uri_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::OptURI do
+  subject(:opt) { described_class.new(['-u', '--uri URI'], attrs) }
+  let(:attrs)   { {} }
+
+  describe '#new, #allowed_protocols' do
+    context 'when no attrs supplied' do
+      its(:allowed_protocols) { should be_empty }
+      its(:default_protocol) { should be nil }
+    end
+
+    context 'when only one protocol supplied' do
+      let(:attrs) { { protocols: 'http' } }
+
+      it 'sets it' do
+        opt.allowed_protocols << 'ftp'
+        expect(opt.allowed_protocols).to eq %w[http ftp]
+      end
+    end
+
+    context 'when multiple protocols are given' do
+      let(:attrs) { { protocols: %w[ftp https] } }
+
+      it 'sets them' do
+        expect(opt.allowed_protocols).to eq attrs[:protocols]
+      end
+    end
+
+    context 'when uppercase protocols' do
+      let(:attrs) { { protocols: %w[ftp HTTPS] } }
+
+      its(:allowed_protocols) { should eq %w[ftp https] }
+    end
+  end
+
+  describe '#append_help_messages' do
+    context 'when no :default_protocol and :allowed_protocols attribute' do
+      its(:help_messages) { should eql([]) }
+    end
+
+    context 'when :default_protocol attribute' do
+      let(:attrs) { super().merge(default_protocol: 'http') }
+
+      its(:help_messages) { should eql ['Default Protocol if none provided: http'] }
+
+      context 'when :default_protocol attribute is uppercase' do
+        let(:attrs) { super().merge(default_protocol: 'HTTPS') }
+
+        its(:help_messages) { should eql ['Default Protocol if none provided: https'] }
+      end
+    end
+
+    context 'when :allowed_protocols attribute' do
+      let(:attrs) { super().merge(protocols: %w[http https]) }
+
+      its(:help_messages) { should eql ['Allowed Protocols: http, https'] }
+    end
+
+    context 'when :allowed_protocols and :default attributes' do
+      let(:attrs) { super().merge(protocols: %w[http https], default: 'https://t.org') }
+
+      its(:help_messages) { should eql ['Allowed Protocols: http, https', 'Default: https://t.org'] }
+    end
+  end
+
+  describe '#validate' do
+    context 'when allowed_protocols is empty' do
+      it 'accepts all protocols' do
+        %w[http ftp file].each do |p|
+          expected = "#{p}://testing"
+
+          expect(opt.validate(expected)).to eq expected
+        end
+      end
+    end
+
+    context 'when allowed_protocols is set' do
+      let(:attrs) { { protocols: %w[https] } }
+
+      it 'raises an error if the protocol is not allowed' do
+        expect { opt.validate('ftp://ishouldnotbethere') }
+          .to raise_error(Addressable::URI::InvalidURIError)
+      end
+
+      it 'returns the uri string if valid' do
+        expected = 'https://example.com/'
+
+        expect(opt.validate(expected)).to eq expected
+      end
+
+      it 'does not raise an error when scheme is upperacse' do
+        expected = 'HTTPS://example.com/'
+
+        expect(opt.validate(expected)).to eq expected
+      end
+    end
+
+    context 'when default_protocol' do
+      let(:attrs) { { default_protocol: 'ftp' } }
+
+      context 'when the argument already contains a protocol' do
+        it 'does not add the default protocol' do
+          expect(opt.validate('http://ex.lo')).to eq 'http://ex.lo'
+        end
+      end
+
+      context 'when no protocol given in the argument' do
+        it 'adds it' do
+          expect(opt.validate('ex.lo')).to eq 'ftp://ex.lo'
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/opt_parse_validator/opts/url_spec.rb
+++ b/spec/lib/opt_parse_validator/opts/url_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::OptURL do
+  subject(:opt) { described_class.new(['-u', '--url URL']) }
+
+  describe '#validate' do
+    context 'when the url is empty' do
+      it 'raises an error' do
+        expect { opt.validate('') }.to raise_error(Addressable::URI::InvalidURIError)
+      end
+    end
+
+    context 'when the protocol is not allowed' do
+      it 'raises an error' do
+        expect { opt.validate('ftp://ftp.domain.com') }
+          .to raise_error(Addressable::URI::InvalidURIError)
+      end
+    end
+
+    it 'returns the url' do
+      url = 'https://duckduckgo.com/'
+
+      expect(opt.validate(url)).to eq url
+    end
+  end
+end

--- a/spec/lib/opt_parse_validator/version_spec.rb
+++ b/spec/lib/opt_parse_validator/version_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+describe OptParseValidator do
+  it 'returns the version' do
+    expect(OptParseValidator::VERSION).to be >= '0'
+  end
+end

--- a/spec/lib/opt_parse_validator_spec.rb
+++ b/spec/lib/opt_parse_validator_spec.rb
@@ -1,0 +1,305 @@
+# frozen_string_literal: true
+
+describe OptParseValidator::OptParser do
+  subject(:parser)  { described_class.new }
+  let(:verbose_opt) { OptParseValidator::OptBoolean.new(%w[-v --verbose Verbose]) }
+  let(:url_opt)     { OptParseValidator::OptURL.new(['-u', '--url URL'], required: true) }
+  let(:alias_opt)   { OptParseValidator::OptAlias.new(%w[-a --alias], alias_for: '-v') }
+
+  describe '#add' do
+    context 'when not an Array<OptBase> or an OptBase' do
+      after { expect { parser.add(*@options) }.to raise_error(*@exception) }
+
+      it 'raises an error when an Array<String>' do
+        @options   = ['string', 'another one']
+        @exception = OptParseValidator::Error, 'The option is not an OptBase, String supplied'
+      end
+    end
+
+    context 'when the option symbol is already used' do
+      after { expect { parser.add(*@options) }.to raise_error(*@exception) }
+
+      it 'raises an error' do
+        @options   = [verbose_opt]
+        @exception = OptParseValidator::Error, 'The option verbose is already used !'
+
+        parser.add(*@options)
+      end
+    end
+
+    context 'when valid' do
+      after do
+        # the #add should return the parser itself, to be able to chain methods
+        expect(parser.add(*@options)).to eql parser
+
+        expect(parser.symbols_used).to eq @expected_symbols
+      end
+
+      it 'adds the options' do
+        @options          = [verbose_opt, url_opt]
+        @expected_symbols = %i[verbose url]
+      end
+
+      it 'adds the option' do
+        @options          = verbose_opt
+        @expected_symbols = [:verbose]
+      end
+    end
+  end
+
+  describe '#results' do
+    before { parser.add(*options) }
+
+    after do
+      if @expected
+        expect(parser.results(@argv)).to eq @expected
+      else
+        expect { parser.results(@argv) }.to raise_error(*@exception)
+      end
+    end
+
+    let(:options) { [verbose_opt, url_opt] }
+
+    context 'when an option is required but not supplied' do
+      it 'raises an error' do
+        @exception = OptParseValidator::NoRequiredOption, 'The option --url is required'
+        @argv      = %w[-v]
+      end
+
+      context 'when long option' do
+        let(:url_opt) { OptParseValidator::OptURL.new(['--url-long URL'], required: true) }
+        let(:options) { [url_opt, verbose_opt] }
+
+        it 'raises an error' do
+          @exception = OptParseValidator::NoRequiredOption, 'The option --url-long is required'
+          @argv      = %w[-v]
+        end
+      end
+    end
+
+    context 'when the #validate raises an error' do
+      it 'adds the option.to_long as a prefix' do
+        @exception = OptParseValidator::Error, '--url Addressable::URI::InvalidURIError'
+        @argv      = %w[--url www.google.com]
+      end
+    end
+
+    context 'when :required_unless' do
+      let(:url_opt)    { OptParseValidator::OptURL.new(['--url URL'], required_unless: :update_long) }
+      let(:update_opt) { OptParseValidator::OptBoolean.new(['--update-long'], required_unless: [:url]) }
+      let(:options)    { [url_opt, update_opt, verbose_opt] }
+
+      context 'when none supplied' do
+        it 'raises an error' do
+          @exception = OptParseValidator::NoRequiredOption,
+                       'One of the following options is required: --url, --update-long'
+          @argv      = %w[-v]
+        end
+      end
+
+      context 'when --url' do
+        it 'returns the expected value' do
+          @expected = { url: 'http://www.g.com' }
+          @argv     = %w[--url http://www.g.com]
+        end
+      end
+
+      context 'when --update-long' do
+        it 'returns the expected value' do
+          @expected = { update_long: true }
+          @argv     = %w[--update-long]
+        end
+      end
+
+      context 'when --url and --update-long' do
+        it 'returns the expected values' do
+          @expected = { url: 'http://www.g.com', update_long: true, verbose: true }
+          @argv     = %w[--url http://www.g.com --update-long -v]
+        end
+      end
+    end
+
+    context 'when the default attribute is used' do
+      let(:options) { [verbose_opt, default_opt] }
+
+      context 'when regular default option' do
+        let(:default_opt) { OptParseValidator::OptBase.new(['--default VALUE'], default: false) }
+
+        context 'when the option is supplied' do
+          it 'overrides the default value' do
+            @argv     = %w[--default overriden]
+            @expected = { default: 'overriden' }
+          end
+        end
+
+        context 'when the option is not supplied' do
+          it 'sets the default value' do
+            @argv     = %w[-v]
+            @expected = { verbose: true, default: false }
+          end
+        end
+      end
+
+      context 'when multi choice with default' do
+        let(:default_opt) do
+          OptParseValidator::OptMultiChoices.new(
+            ['--enum [Options]'],
+            choices: {
+              a: OptParseValidator::OptBoolean.new(['--aa']),
+              b: OptParseValidator::OptBoolean.new(['--bb'])
+            },
+            value_if_empty: 'a,b',
+            default: { aa: true }
+          )
+        end
+
+        context 'when the option is supplied' do
+          it 'overrides the default value' do
+            @argv     = %w[--enum a,b]
+            @expected = { enum: { aa: true, bb: true } }
+          end
+        end
+
+        context 'when the option is not supplied' do
+          it 'sets the default value' do
+            @argv     = %w[-v]
+            @expected = { verbose: true, enum: { aa: true } }
+          end
+        end
+      end
+    end
+
+    # See https://github.com/wpscanteam/CMSScanner/issues/2
+    context 'when no short option' do
+      let(:options)  { [verbose_opt, http_opt] }
+      let(:http_opt) { OptParseValidator::OptBase.new(['--http-auth log:pass']) }
+
+      it 'calls the help' do
+        expect(parser).to receive(:help)
+
+        @argv      = %w[-h]
+        @exception = SystemExit
+      end
+
+      it 'returns the results' do
+        @argv     = %w[--http-auth user:passwd]
+        @expected = { http_auth: 'user:passwd' }
+      end
+    end
+
+    context 'when the normalize attribute is used' do
+      let(:options) { [OptParseValidator::OptString.new(['--test V'], normalize: :to_sym)] }
+
+      it 'returns the symbol' do
+        @argv     = %w[--test test]
+        @expected = { test: :test }
+      end
+    end
+
+    context 'when an alias is used' do
+      let(:options) { super() << alias_opt }
+
+      context 'when called in the cli' do
+        it 'returns the expected hash' do
+          @argv = %w[--url http://a.org --alias]
+          @expected = { url: 'http://a.org', verbose: true }
+        end
+      end
+
+      context 'when not called in the cli' do
+        it 'returns the expected hash' do
+          @argv = %w[--url http://a.org]
+          @expected = { url: 'http://a.org' }
+        end
+      end
+    end
+
+    it 'returns the results' do
+      @argv     = %w[--url http://hello.com -v]
+      @expected = { url: 'http://hello.com', verbose: true }
+    end
+  end
+
+  describe '#simple_help, #full_help' do
+    before { parser.add(*options) }
+
+    let(:fixtures)    { OPV_FIXTURES.join('advanced_help') }
+    let(:options)     { [verbose_opt, url_opt] }
+    let(:simple_help) { File.read(fixtures.join('no_advanced.txt')) }
+
+    describe ' when no advanced options' do
+      its(:simple_help) { should eql simple_help }
+      its(:full_help)   { should eql parser.simple_help }
+    end
+
+    describe 'when advanced options' do
+      let(:options) do
+        super() <<
+          OptParseValidator::OptBoolean.new(['--[no-]banner', 'aaa aaa'], advanced: true) <<
+          OptParseValidator::OptString.new(['-s', '--short ARG', 'Option', 'Multi Line'], advanced: true) <<
+          OptParseValidator::OptBoolean.new(['-a', '--all', 'Short and long option'], advanced: true)
+      end
+
+      its(:simple_help) { should eql simple_help }
+      its(:full_help)   { should eql File.read(fixtures.join('with_advanced.txt')) }
+    end
+  end
+
+  describe '#load_config_files' do
+    let(:fixtures)       { OPV_FIXTURES.join('config_files_loader_merger') }
+    let(:default_file)   { fixtures.join('default.json') }
+    let(:override_file)  { fixtures.join('override.yml') }
+    let(:malformed_file) { fixtures.join('malformed.yml') }
+    let(:override_opt)   { OptParseValidator::OptString.new(['--override-me VALUE'], normalize: :to_sym) }
+    let(:opts)           { [verbose_opt, override_opt] }
+    let(:expected)       { { verbose: true, override_me: :Yeaa } }
+
+    before do
+      parser.config_files << default_file << override_file
+      parser.add(*opts)
+    end
+
+    context 'when the file is malformed' do
+      before { parser.config_files << malformed_file }
+
+      it 'raises an OptParseValidator::Error' do
+        expect { parser.results([]) }.to raise_error OptParseValidator::Error
+      end
+    end
+
+    context 'when no cli options supplied' do
+      it 'sets everything correctly and get the right results' do
+        expect(parser.results([])).to eql expected
+      end
+    end
+
+    context 'when cli options provided' do
+      it 'prioritize the cli one' do
+        expect(parser.results(%w[--override-me cli])).to eql expected.merge(override_me: :cli)
+      end
+    end
+
+    context 'when multi choices given as boolean in options file' do
+      let(:enum_file) { fixtures.join('enum.yml') }
+      let(:enum_opt) do
+        OptParseValidator::OptMultiChoices.new(
+          ['--enum [Options]'],
+          choices: {
+            a: OptParseValidator::OptBoolean.new(['--aa']),
+            b: OptParseValidator::OptBoolean.new(['--bb'])
+          },
+          value_if_empty: 'a,b'
+        )
+      end
+
+      before do
+        parser.config_files << enum_file
+        parser.add(enum_opt)
+      end
+
+      it 'raises an error with the option.to_long as a prefix' do
+        expect { parser.results([]) }.to raise_error(OptParseValidator::Error, '--enum Unknown choice: true')
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -115,6 +115,7 @@ FIXTURES_MODELS          = FIXTURES.join('models')
 FIXTURES_CONTROLLERS     = FIXTURES.join('controllers')
 FIXTURES_VIEWS           = FIXTURES.join('views')
 DYNAMIC_FINDERS_FIXTURES = FIXTURES.join('dynamic_finders')
+OPV_FIXTURES             = FIXTURES.join('opt_parse_validator')
 APP_VIEWS                = File.join(WPScan::APP_DIR, 'views')
 ERROR_404_URL_PATTERN    = %r{/[a-z\d]{7}\.html$}
 

--- a/wpscan.gemspec
+++ b/wpscan.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |s|
   s.require_paths         = ['lib']
 
   s.add_dependency 'activesupport',        '>= 7.1', '< 8.1'
+  s.add_dependency 'addressable',          '>= 2.5', '< 2.9'
   s.add_dependency 'ethon',                '>= 0.14', '< 0.17'
   s.add_dependency 'get_process_mem',      '>= 0.2.5', '< 1.1.0'
   s.add_dependency 'nokogiri',             '~> 1.16'
-  s.add_dependency 'opt_parse_validator',  '~> 1.10.1'
   s.add_dependency 'public_suffix',        '>= 4.0.3', '< 6.1'
   s.add_dependency 'ruby-progressbar',     '>= 1.10', '< 1.14'
   s.add_dependency 'sys-proctable',        '>= 1.2.2', '< 1.4.0'


### PR DESCRIPTION
Pretty much the same as https://github.com/wpscanteam/wpscan/pull/1977 - only that `opt_parse_validatpr` was a dependency of CMSScanner before (and thus a transient dependency for our project).

With the completion of this, we should have everything we develop in house for the WPScan CLI in this same repo.

## Proposed changes

  * Copied the `opt_parse_validator` gem source into `lib/opt_parse_validator/` and its specs into `spec/lib/opt_parse_validator/`.
  * Dropped the `opt_parse_validator` runtime dependency from `wpscan.gemspec` and added `addressable` as an explicit top-level dependency (previously pulled in transitively, though already `require`d directly).
  * Kept the `OptParseValidator::` namespace unchanged — no call-site edits needed in existing wpscan code.
  * Applied minor rubocop cleanups to the copied code to conform to wpscan's stricter config (line length, `File.open` block form, modernized range slicing, etc.).

  ## Why are these changes being made?

  `opt_parse_validator` is maintained by the same team and is only consumed by wpscan in practice. Keeping it as a separate gem forces a release cycle for every CLI-option change, which potentially slows development. This follows the same pattern as the recent `cms_scanner` merge (#1977, #1978): fewer repos, one place to make and test changes.

  The namespace is preserved (unlike the `cms_scanner` merge) because `opt_parse_validator` is a leaf utility library, not an application framework. Keeping `OptParseValidator::` minimizes the things we had to do here, keeps the internal boundary clean, and leaves the door open to re-extract if ever needed.

  ## Testing instructions

  * `bundle install` -> confirm `Gemfile.lock` no longer lists `opt_parse_validator` and shows `addressable` at the top level.
  * `bundle exec rubocop` -> should pass clean (452 files, 0 offenses).
  * `bundle exec rspec --tag '~slow'` -> should pass (10422 examples, 0 failures; +666 new examples vs. pre-merge from the ported opt_parse_validator specs).
  * Smoke test the CLI: `ruby -Ilib bin/wpscan --help` -> banner and option list should render without error, confirming `require 'opt_parse_validator'` resolves to the vendored copy and `include OptParseValidator` in `lib/wpscan/controller.rb` still works.

Or.. just trust the GitHub CI because we have these cool new integration tests now 🙂 