### PR TITLE
Expand integration test coverage for Ruby versions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,6 +13,10 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        ruby: [3.3, 3.4, 4.0]
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -49,10 +53,10 @@ jobs:
     - name: Verify WordPress site is accessible
       run: curl -k -f https://wordpress-test.ddev.site
 
-    - name: Set up Ruby
+    - name: Set up Ruby ${{ matrix.ruby }}
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '4.0'
+        ruby-version: ${{ matrix.ruby }}
 
     - name: Install GEMs and build WPScan
       run: |
@@ -102,5 +106,5 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: integration-test-results
+        name: integration-test-results-ruby-${{ matrix.ruby }}
         path: scan-results.json


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Related to #1978

## Proposed changes

* Add matrix strategy to run integration tests on Ruby 3.3, 3.4, and 4.0 (matching unit test coverage)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Integration tests should run on all Ruby versions we support (3.3, 3.4, 4.0) like unit tests do, not just Ruby 4.0. This ensures it works correctly across all supported Ruby platforms and catches version-specific issues early.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Trust the CI