### PR TITLE
Document proxy hostname resolution in the CLI option description.

### DIFF
--- a/app/controllers/core/cli_options.rb
+++ b/app/controllers/core/cli_options.rb
@@ -79,7 +79,10 @@ module WPScan
       def cli_browser_proxy_options
         [
           OptProxy.new(['--proxy protocol://IP:port',
-                        'Supported protocols depend on the cURL installed']),
+                        'Supported protocols depend on the cURL installed. ' \
+                        'Note: with socks5://, hostnames are resolved locally before being ' \
+                        'sent to the proxy; use socks5h:// to have the proxy resolve them ' \
+                        '(required for .onion addresses when proxying through Tor).']),
           OptCredentials.new(['--proxy-auth login:password'])
         ]
       end


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Fixes https://github.com/wpscanteam/wpscan/issues/1915

## Proposed changes

  * Document the `socks5://` vs `socks5h://` distinction in the `--proxy` CLI help text, so users scanning `.onion` targets (e.g. through Tor) know they need `socks5h://` to have the proxy resolve hostnames. Change is in `app/controllers/core/cli_options.rb`.

  ## Why are these changes being made?

  * Reported in [#1915](https://github.com/wpscanteam/wpscan/issues/1915): scans of `.onion` URLs through a Tor SOCKS5 proxy fail with "Could not resolve hostname" / "proxy handshake error". The root cause is libcurl's behavior: `socks5://` resolves hostnames **locally** before sending the request, which cannot work for `.onion` domains since they have no public DNS. The `socks5h://` scheme delegates resolution to  the proxy (equivalent to `curl --socks5-hostname`) and works correctly.
  * `wpscan` already passes the `--proxy` value straight through to libcurl, so no code change is required — both schemes are supported today.

  ## Testing instructions

Get a local tor proxy running:

```sh
brew install tor && tor
```

  **1. Reproduce the original bug (should fail):**

  ```sh
  bundle exec ruby -Ilib bin/wpscan \
    --url https://duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion/ \
    --proxy socks5://127.0.0.1:9050 \
    --random-user-agent --disable-tls-checks
  ```

  Expected: `Scan Aborted: The url supplied '...' seems to be down` (proxy handshake error / could not resolve hostname). This is the pre-existing behavior that motivated the doc change.

  **2. Confirm the documented workaround works:**

  ```sh
  bundle exec ruby -Ilib bin/wpscan \
    --url https://duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion/ \
    --proxy socks5h://127.0.0.1:9050 \
    --random-user-agent --disable-tls-checks
  ```

  Expected: the scan proceeds past `check_target_availability` and reaches the target over Tor. (The DuckDuckGO site that this is the onion address of above is not a WordPress site, so wpscan will report that it does not seem to be running WordPress and then abort - that's fine; the fix is proven because the connection and hostname resolution succeeded through the proxy.) Also I don't have a onion WP site handy to test further but I don't see why it would not work 🙂 
