### PR TITLE
Document $ character escaping for --http-auth option

### DIFF
--- a/app/controllers/core/cli_options.rb
+++ b/app/controllers/core/cli_options.rb
@@ -51,7 +51,8 @@ module WPScan
                           exists: true,
                           advanced: true,
                           default: APP_DIR.join('user_agents.txt')),
-          OptCredentials.new(['--http-auth login:password']),
+          OptCredentials.new(['--http-auth login:password',
+                              'Basic HTTP authentication, beware that the $ character must be properly escaped.']),
           OptPositiveInteger.new(['-t', '--max-threads VALUE', 'The max threads to use'],
                                  default: 5),
           OptPositiveInteger.new(['--throttle MilliSeconds', 'Milliseconds to wait before doing another web request. ' \


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Fixes #1734

## Proposed changes

* Add help text to `--http-auth` option documenting that the `$` character must be properly escaped

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Users scanning WordPress sites protected by basic authentication with passwords containing `$` characters were experiencing authentication failures. The root cause is shell variable interpolation: when passing credentials like `--http-auth user:pass$word`, the shell expands `$word` as a variable (typically empty), effectively truncating the password.

This issue was reported in #1734 and the fix was originally proposed in wpscanteam/CMSScanner#248, but that PR was never merged. Since PR #1977 merged the CMSScanner gem into wpscan, we can now apply this documentation fix directly.

The help text now warns users about this common pitfall and guides them to use proper escaping (single quotes or backslash escaping).

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Verify the help text displays correctly:
```
bundle exec ruby -Ilib bin/wpscan --help | grep -A 2 "http-auth"
```