### PR TITLE
Limit the maximum size of PHP log files that we inspect to 20 MiB to avoid memory exhaustion on sites serving huge log files. 

### DIFF
--- a/app/controllers/core/cli_options.rb
+++ b/app/controllers/core/cli_options.rb
@@ -37,7 +37,12 @@ module WPScan
           OptBoolean.new(['--[no-]banner', 'Whether or not to display the banner'], default: true),
           OptPositiveInteger.new(['--max-scan-duration SECONDS',
                                   'Abort the scan if it exceeds the time provided in seconds'],
-                                 advanced: true)
+                                 advanced: true),
+          OptPositiveInteger.new(['--max-log-file-size MiB',
+                                  'Skip inspection of PHP log files (debug.log, error_log, ...) ' \
+                                  'when their advertised or transferred size exceeds this value, in MiB. ' \
+                                  'Guards against memory exhaustion on sites serving huge log files.'],
+                                 default: 20, advanced: true)
         ]
       end
 

--- a/lib/wpscan/target/platform/php.rb
+++ b/lib/wpscan/target/platform/php.rb
@@ -16,11 +16,73 @@ module WPScan
         #
         # @return [ Boolean ]
         def log_file?(path, pattern, params = {})
-          # Only the first 700 bytes of the file are retrieved to avoid getting entire log file
-          # which can be huge (~ 2Go)
-          res = head_and_get(path, [200], get: params.merge(headers: { 'Range' => 'bytes=0-700' }))
+          max_mib  = WPScan::ParsedCli.max_log_file_size.to_i
+          max_size = max_mib.positive? ? max_mib * 1024 * 1024 : nil
 
-          res.body&.match?(pattern) || false
+          head_res = WPScan::Browser.forge_request(url(path), head_or_get_params).run
+          return false unless head_res.code == 200
+
+          if max_size
+            content_length = head_res.headers&.[]('Content-Length').to_i
+            return false if content_length > max_size
+          end
+
+          body = stream_capped_body(path, params, max_size)
+          return false if body.nil?
+
+          body.match?(pattern) || false
+        end
+
+        # Performs a streaming GET of `path` and returns the body as a String, capped at
+        # `max_size` bytes. Returns nil if the transfer was aborted because it exceeded the cap.
+        #
+        # Only the first 700 bytes of the file are needed to match log-file patterns. Servers may
+        # ignore the Range header, and libcurl's maxfilesize is a no-op when the response has no
+        # Content-Length (chunked transfer encoding), so an on_body callback is used to abort the
+        # transfer once the accumulated body exceeds the configured limit. Streaming via on_body
+        # also keeps Typhoeus::Response#body empty, so the response cache cannot Marshal-dump a
+        # huge payload.
+        #
+        # @param [ String ]       path
+        # @param [ Hash ]         params The base request params
+        # @param [ Integer, nil ] max_size Size cap in bytes, or nil to disable
+        #
+        # @return [ String, nil ]
+        def stream_capped_body(path, params, max_size)
+          get_params = params.merge(
+            headers: { 'Range' => 'bytes=0-700' },
+            method: :get,
+            cache_ttl: 0
+          )
+          get_params[:maxfilesize] = max_size if max_size
+
+          req  = WPScan::Browser.forge_request(url(path), get_params)
+          body = +''
+          aborted = install_body_cap(req, body, max_size)
+          req.run
+
+          aborted.call ? nil : body
+        end
+
+        # Installs an on_body callback on `req` that appends chunks to `body`. If `max_size` is
+        # set, the transfer is aborted once the buffer exceeds it. Returns a callable that
+        # reports whether the transfer was aborted.
+        def install_body_cap(req, body, max_size)
+          aborted = false
+
+          if max_size
+            req.on_body do |chunk|
+              body << chunk
+              next if body.bytesize <= max_size
+
+              aborted = true
+              :abort
+            end
+          else
+            req.on_body { |chunk| body << chunk }
+          end
+
+          -> { aborted }
         end
 
         # @param [ String ] path

--- a/spec/app/finders/interesting_findings/debug_log_spec.rb
+++ b/spec/app/finders/interesting_findings/debug_log_spec.rb
@@ -15,9 +15,11 @@ describe WPScan::Finders::InterestingFindings::DebugLog do
 
   describe '#aggressive' do
     before do
-      stub_request(:head, log_url)
+      stub_request(:head, log_url).to_return(head_response)
       stub_request(:get, log_url).to_return(body: body)
     end
+
+    let(:head_response) { { status: 200 } }
 
     context 'when empty file' do
       let(:body) { '' }
@@ -34,6 +36,63 @@ describe WPScan::Finders::InterestingFindings::DebugLog do
           confidence: 100,
           found_by: described_class::DIRECT_ACCESS
         )
+      end
+    end
+
+    context 'when HEAD advertises a Content-Length above the configured limit' do
+      let(:body)          { File.read(fixtures.join('debug.log')) }
+      let(:head_response) { { status: 200, headers: { 'Content-Length' => (50 * 1024 * 1024).to_s } } }
+
+      before { WPScan::ParsedCli.options = { max_log_file_size: 20 } }
+      after  { WPScan::ParsedCli.options = {} }
+
+      it 'skips the GET and returns nil' do
+        expect(finder.aggressive).to be_nil
+        expect(a_request(:get, log_url)).not_to have_been_made
+      end
+    end
+
+    context 'when HEAD advertises a Content-Length below the configured limit' do
+      let(:body)          { File.read(fixtures.join('debug.log')) }
+      let(:head_response) { { status: 200, headers: { 'Content-Length' => '500' } } }
+
+      before { WPScan::ParsedCli.options = { max_log_file_size: 20 } }
+      after  { WPScan::ParsedCli.options = {} }
+
+      it 'fetches the body via a streaming GET with maxfilesize set and matches the pattern' do
+        allow(WPScan::Browser).to receive(:forge_request).and_call_original
+        expect(WPScan::Browser).to receive(:forge_request).with(
+          log_url,
+          hash_including(maxfilesize: 20 * 1024 * 1024, cache_ttl: 0, method: :get)
+        ).and_call_original
+
+        expect(finder.aggressive).to eql WPScan::Model::DebugLog.new(
+          log_url,
+          confidence: 100,
+          found_by: described_class::DIRECT_ACCESS
+        )
+      end
+    end
+
+    context 'when the server does not expose Content-Length (chunked transfer)' do
+      let(:head_response) { { status: 200 } }
+      let(:body)          { File.read(fixtures.join('debug.log')) }
+
+      before { WPScan::ParsedCli.options = { max_log_file_size: 20 } }
+      after  { WPScan::ParsedCli.options = {} }
+
+      it 'still issues a streaming GET with an on_body callback so large payloads can be aborted' do
+        captured_req = nil
+        allow(WPScan::Browser).to receive(:forge_request).and_wrap_original do |m, *args|
+          req = m.call(*args)
+          captured_req = req if args.first == log_url && args[1][:method] == :get
+          req
+        end
+
+        finder.aggressive
+
+        expect(captured_req).not_to be_nil
+        expect(captured_req.on_body).not_to be_empty
       end
     end
   end


### PR DESCRIPTION
This feature is configurable via the new --max-log-file-size parameter.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Fixes https://github.com/wpscanteam/wpscan/issues/1910

## Proposed changes

  * Add a new `--max-log-file-size MiB` CLI option (default: 20, advanced) that caps the size of PHP log files (`debug.log`, `error_log`, ...) WPScan is willing to inspect.
  * Rework `WPScan::Target::Platform::PHP#log_file?` to apply three layered defenses against oversized responses on log-file probes:
    1. A `Range: bytes=0-700` header is still sent (polite hint for well-behaved servers).
    2. A HEAD request is issued first; if the advertised `Content-Length` exceeds the cap, the GET is skipped entirely.
    3. The GET is streamed via a Typhoeus `on_body` callback; the transfer is aborted with `:abort` as soon as the buffered body exceeds the cap. `cache_ttl: 0` is also set on the request so the oversized response is never handed to the cache layer.

  ## Why are these changes being made?

  Reported in [wpscanteam/wpscan#1910](https://github.com/wpscanteam/wpscan/issues/1910): scanning a target whose `/wp-content/debug.log` returns a multi-GiB response crashes WPScan with `Scan Aborted: long too big to dump`. The trace points to `Marshal.dump` inside the Typhoeus cache, which cannot serialize strings larger than `2^31 - 1` bytes.

  The limit is configurable, so operators inspecting sites with legitimately large (but still sane) logs can raise it if they'd like to.

  ## Testing instructions


A bit complex, please talk to me, reviewer. 🙂 
