### PR TITLE
Added dynamic finder for SearchWP premium plugin

### DIFF
--- a/spec/fixtures/db/dynamic_finders.yml
+++ b/spec/fixtures/db/dynamic_finders.yml
@@ -100057,6 +100057,12 @@ plugins:
   searchpro:
     Readme:
       path: readme.txt
+  searchwp:
+    TranslationFile:
+      class: BodyPattern
+      path: languages/searchwp.pot
+      pattern: !ruby/regexp '/"Project\-Id\-Version: SearchWP (?<v>\d+\.[\.\d]+)/i'
+      version: true
   searchwp-live-ajax-search:
     QueryParameter:
       files:

--- a/spec/fixtures/dynamic_finders/expected.yml
+++ b/spec/fixtures/dynamic_finders/expected.yml
@@ -49311,6 +49311,13 @@ plugins:
       - http://wp.lab/wp-content/plugins/searching-for-posts/public/js/jsrender.js?ver=1.0.0
       - http://wp.lab/wp-content/plugins/searching-for-posts/public/js/searching-for-posts-public.js?ver=1.0.0
       confidence: 30
+  searchwp:
+    TranslationFile:
+      number: 4.3.16
+      found_by: Translation File (Aggressive Detection)
+      interesting_entries:
+      - 'http://wp.lab/wp-content/plugins/searchwp/languages/searchwp.pot, Match:
+        ''"Project-Id-Version: SearchWP 4.3.16'''
   searchwp-live-ajax-search:
     QueryParameter:
       number: 1.2.0

--- a/spec/fixtures/dynamic_finders/plugin_version/searchwp/translation_file/languages/searchwp.pot
+++ b/spec/fixtures/dynamic_finders/plugin_version/searchwp/translation_file/languages/searchwp.pot
@@ -1,0 +1,12 @@
+# Copyright (C) 2023 SearchWP, LLC
+# This file is distributed under the same license as the SearchWP plugin.
+msgid ""
+msgstr ""
+"Project-Id-Version: SearchWP 4.3.16\n"
+"Report-Msgid-Bugs-To: https://searchwp.com/support/\n"
+"POT-Creation-Date: 2023-09-01T00:00:00+00:00\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: WP-CLI 2.8.1\n"
+"X-Domain: searchwp\n"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Resolves https://github.com/wpscanteam/wpscan/issues/1908
## Proposed changes

  * Add a new dynamic finder for the [SearchWP](https://searchwp.com/) plugin (slug: `searchwp`) that detects the installed version by fetching `languages/searchwp.pot` and extracting the version from its `Project-Id-Version` header.
  * Add test coverage for it

  ## Why are these changes being made?

  *  To detect the version of that plugin too (as was requested in the issue).

  ## Testing instructions

Run it against my test site:

```
bundle exec ruby -Ilib bin/wpscan --url https://ticktramp.s6-tastewp.com/
```

it should show something like this:

```
[...]
[+] searchwp
 | Location: https://ticktramp.s6-tastewp.com/wp-content/plugins/searchwp/
 |
 | Found By: Urls In Homepage (Passive Detection)
 |
 | The version could not be determined.
[...]
```

then, switch to this branch and copy over the dynamic finders to your local database location:

```
git checkout add-searchwp-dynamic-finder
cp ./spec/fixtures/db/dynamic_finders.yml ~/.wpscan/db/dynamic_finders.yml
```

run the scan again and this time it should detect the version:

```
[+] searchwp
 | Location: https://ticktramp.s6-tastewp.com/wp-content/plugins/searchwp/
 |
 | Found By: Urls In Homepage (Passive Detection)
 |
 | Version: 4.5.8 (60% confidence)
 | Found By: Translation File (Aggressive Detection)
 |  - https://ticktramp.s6-tastewp.com/wp-content/plugins/searchwp/languages/searchwp.pot, Match: '"Project-Id-Version: SearchWP 4.5.8'
```

Also, double check the tests for the that added dynamic finder work (since all of them only run once we merge this to master):

```
$ bundle exec rspec -e "Searchwp::TranslationFile"                                                                                                                                                          130 ↵
Run options: include {full_description: /Searchwp::TranslationFile/}
...

Finished in 0.34347 seconds (files took 8.19 seconds to load)
3 examples, 0 failures

Coverage report generated for RSpec to /Users/kolja/projects/wpscan/coverage.
Line Coverage: 53.17% (2173 / 4087)
Branch Coverage: 5.44% (59 / 1084)
```