### PR TITLE
Default to $TMPDIR if it is set, only otherwise use /tmp.

### DIFF
--- a/lib/wpscan/controller.rb
+++ b/lib/wpscan/controller.rb
@@ -72,7 +72,7 @@ module WPScan
 
       # @return [ String ]
       def tmp_directory
-        File.join('/tmp', WPScan.app_name)
+        File.join(ENV['TMPDIR'] || '/tmp', WPScan.app_name)
       end
 
       protected

--- a/spec/lib/controller_spec.rb
+++ b/spec/lib/controller_spec.rb
@@ -15,9 +15,22 @@ describe WPScan::Controller do
   its(:option_parser)         { should be nil }
   its(:formatter)             { should be_a WPScan::Formatter::Cli }
   its(:user_interaction?)     { should be true }
-  its(:tmp_directory)         { should eql '/tmp/wpscan' }
   its(:target)                { should be_a WPScan::Target }
   its('target.scope.domains') { should eq [PublicSuffix.parse('example.com')] }
+
+  describe '#tmp_directory' do
+    context 'when TMPDIR is not set' do
+      before { stub_const('ENV', ENV.to_hash.tap { |e| e.delete('TMPDIR') }) }
+
+      its(:tmp_directory) { should eql '/tmp/wpscan' }
+    end
+
+    context 'when TMPDIR is set' do
+      before { stub_const('ENV', ENV.to_hash.merge('TMPDIR' => '/home/user/tmp')) }
+
+      its(:tmp_directory) { should eql '/home/user/tmp/wpscan' }
+    end
+  end
 
   context 'when output option' do
     let(:parsed_options) { super().merge(output: '/tmp/spec.txt') }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ RSpec.configure do |config|
   end
 
   # For --only-failures / --next-failure
-  config.example_status_persistence_file_path = '/tmp/rspec_examples.txt'
+  config.example_status_persistence_file_path = File.join(ENV['TMPDIR'] || '/tmp', 'rspec_examples.txt')
 end
 
 def redefine_constant(constant, value)


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Resolves https://github.com/wpscanteam/wpscan/issues/1893

## Proposed changes

* Default to [$TMPDIR](https://en.wikipedia.org/wiki/TMPDIR) if it is set, only otherwise use /tmp.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Security concerns on multi-user-systems, so let's use more sensible default.s

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Tests and CI should cover it.


