### PR TITLE
Add --follow-redirect option to automatically follow redirects

### DIFF
--- a/app/controllers/core.rb
+++ b/app/controllers/core.rb
@@ -81,12 +81,8 @@ module WPScan
         effective_url = target.homepage_res.effective_url # get and follow location of target.url
         effective_uri = Addressable::URI.parse(effective_url)
 
-        # http://a.com => https://a.com (or the opposite)
-        if !WPScan::ParsedCli.ignore_main_redirect && target.uri.domain == effective_uri.domain &&
-           target.uri.path == effective_uri.path && target.uri.scheme != effective_uri.scheme
-
-          target.url = effective_url
-        end
+        handle_scheme_redirect(effective_url, effective_uri)
+        handle_follow_redirect(effective_url, effective_uri)
 
         return if target.in_scope?(effective_url)
 
@@ -94,6 +90,30 @@ module WPScan
 
         # Sets homepage_res back to unfollowed response when ignore_main_redirect is used
         target.homepage_res = res
+      end
+
+      # Handles scheme-only redirects (http => https or vice versa)
+      #
+      # @param [ String ] effective_url
+      # @param [ Addressable::URI ] effective_uri
+      def handle_scheme_redirect(effective_url, effective_uri)
+        # http://a.com => https://a.com (or the opposite)
+        if !WPScan::ParsedCli.ignore_main_redirect && target.uri.domain == effective_uri.domain &&
+           target.uri.path == effective_uri.path && target.uri.scheme != effective_uri.scheme
+
+          target.url = effective_url
+        end
+      end
+
+      # Handles --follow-redirect option
+      #
+      # @param [ String ] effective_url
+      # @param [ Addressable::URI ] effective_uri
+      def handle_follow_redirect(effective_url, effective_uri)
+        return unless WPScan::ParsedCli.follow_redirect && target.url != effective_url
+
+        target.url = effective_url
+        target.scope << effective_uri.host
       end
 
       # @return [ DB::Updater ]

--- a/app/controllers/core/cli_options.rb
+++ b/app/controllers/core/cli_options.rb
@@ -33,6 +33,8 @@ module WPScan
           OptBoolean.new(['--version', 'Display the version and exit']),
           OptBoolean.new(['--ignore-main-redirect', 'Ignore the main redirect (if any) and scan the target url'],
                          advanced: true),
+          OptBoolean.new(['--follow-redirect', 'Automatically update the URL to the destination of the redirect'],
+                         advanced: true),
           OptBoolean.new(['-v', '--verbose', 'Verbose mode']),
           OptBoolean.new(['--[no-]banner', 'Whether or not to display the banner'], default: true),
           OptPositiveInteger.new(['--max-scan-duration SECONDS',

--- a/app/controllers/core/cli_options.rb
+++ b/app/controllers/core/cli_options.rb
@@ -31,7 +31,9 @@ module WPScan
           OptBoolean.new(['-h', '--help', 'Display the simple help and exit']),
           OptBoolean.new(['--hh', 'Display the full help and exit']),
           OptBoolean.new(['--version', 'Display the version and exit']),
-          OptBoolean.new(['--ignore-main-redirect', 'Ignore the main redirect (if any) and scan the target url'],
+          OptBoolean.new(['--ignore-main-redirect',
+                          'Ignore the main redirect (if any) and scan the target url. ' \
+                          'Has no effect if --follow-redirect is set.'],
                          advanced: true),
           OptBoolean.new(['--follow-redirect', 'Automatically update the URL to the destination of the redirect'],
                          advanced: true),

--- a/lib/wpscan/errors/http.rb
+++ b/lib/wpscan/errors/http.rb
@@ -96,7 +96,8 @@ module WPScan
       end
 
       def to_s
-        "The URL supplied redirects to #{redirect_uri}. Use the --ignore-main-redirect " \
+        "The URL supplied redirects to #{redirect_uri}. Use the --follow-redirect " \
+          'option to automatically scan the redirected URL, the --ignore-main-redirect ' \
           'option to ignore the redirection and scan the target, or change the --url option ' \
           'value to the redirected URL.'
       end

--- a/spec/app/controllers/core_spec.rb
+++ b/spec/app/controllers/core_spec.rb
@@ -221,6 +221,51 @@ describe WPScan::Controller::Core do
           it 'raises an error' do
             expect { core.before_scan }.to raise_error(WPScan::Error::HTTPRedirect)
           end
+
+          context 'when --follow-redirect' do
+            let(:cli_args) { "#{super()} --follow-redirect" }
+
+            it 'updates the target URL and does not raise an error' do
+              expect(core).to receive(:load_server_module)
+              expect(core.target).to receive(:wordpress?).with(:mixed).and_return(true)
+
+              expect { core.before_scan }.to_not raise_error
+              expect(core.target.url).to eq(redirection)
+            end
+          end
+        end
+
+        context 'to a different domain with different path' do
+          let(:redirection) { 'http://g.com/blog/' }
+
+          it 'raises an error without --follow-redirect' do
+            expect { core.before_scan }.to raise_error(WPScan::Error::HTTPRedirect)
+          end
+
+          context 'when --follow-redirect' do
+            let(:cli_args) { "#{super()} --follow-redirect" }
+
+            it 'updates the target URL and adds domain to scope' do
+              expect(core).to receive(:load_server_module)
+              expect(core.target).to receive(:wordpress?).with(:mixed).and_return(true)
+
+              expect { core.before_scan }.to_not raise_error
+              expect(core.target.url).to eq(redirection)
+              expect(core.target.in_scope?('http://g.com/other')).to be true
+            end
+          end
+
+          context 'when both --follow-redirect and --ignore-main-redirect' do
+            let(:cli_args) { "#{super()} --follow-redirect --ignore-main-redirect" }
+
+            it 'follows the redirect (--follow-redirect takes precedence)' do
+              expect(core).to receive(:load_server_module)
+              expect(core.target).to receive(:wordpress?).with(:mixed).and_return(true)
+
+              expect { core.before_scan }.to_not raise_error
+              expect(core.target.url).to eq(redirection)
+            end
+          end
         end
 
         context 'to another path with the wp-admin/install.php in the query' do


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Fixes to #1832

## Proposed changes

* Added new `--follow-redirect` CLI option (advanced option)
* Refactored redirect handling in `Core` controller into separate helper methods for clarity
* Updated `HTTPRedirect` error message to mention the new option
* Added comprehensive test coverage for the new behavior

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Users reported that WPScan aborts when it detects a redirect to a different domain, requiring manual intervention to either use `--ignore-main-redirect` (which scans the original URL) or manually update the `--url` parameter. This is particularly problematic when running automated scans via scripts.

The new `--follow-redirect` option automatically updates the target URL to the redirect destination and adds the redirected domain to the scan scope, allowing scans to continue seamlessly. This differs from `--ignore-main-redirect` which scans the original URL while ignoring the redirect.

This change improves the user experience for automated scanning scenarios while maintaining backward compatibility (opt-in behavior).

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Trust the CI, or:

1. Set up a site that redirects to a different domain (e.g. https://malissunderground.wordpress.com/ -> https://malissunderground.wpcomstaging.com/)
2. **Test without the flag (existing behavior):**
   ```bash
   bundle exec ruby -Ilib bin/wpscan --url https://malissunderground.wordpress.com/
   ```
   Expected: Should abort with HTTPRedirect error message mentioning `--follow-redirect` option
3. **Test with --follow-redirect:**
   ```bash
   bundle exec ruby -Ilib bin/wpscan --url https://malissunderground.wordpress.com/ --follow-redirect
   ```
   Expected: Should update target URL to `https://malissunderground.wpcomstaging.com/` and continue scanning

4. **Test with both --follow-redirect and --ignore-main-redirect:**
   ```bash
   bundle exec ruby -Ilib bin/wpscan --url https://malissunderground.wordpress.com/ --follow-redirect --ignore-main-redirect
   ```
   Expected: Should follow the redirect (--follow-redirect takes precedence)