### PR TITLE
Fix Errno::ENAMETOOLONG when using long comma-separated lists

### DIFF
--- a/lib/opt_parse_validator/opts/smart_list.rb
+++ b/lib/opt_parse_validator/opts/smart_list.rb
@@ -23,7 +23,7 @@ module OptParseValidator
     def validate(value)
       # Might be a better way to do this especially with a big file
       File.open(value) { |f| f.map(&:chomp) }
-    rescue Errno::ENOENT
+    rescue Errno::ENOENT, Errno::ENAMETOOLONG
       super
     end
   end

--- a/spec/lib/opt_parse_validator/opts/smart_list_spec.rb
+++ b/spec/lib/opt_parse_validator/opts/smart_list_spec.rb
@@ -64,5 +64,28 @@ describe OptParseValidator::OptSmartList do
         end
       end
     end
+
+    context 'when a very long comma-separated list' do
+      let(:long_list) do
+        'wordpress-seo,jetpack,contact-form-7,woocommerce,elementor,wordfence,wp-super-cache,' \
+          'wp-mail-smtp,duplicate-post,classic-editor,akismet,google-analytics-for-wordpress,' \
+          'all-in-one-seo-pack,really-simple-ssl,wpforms-lite,updraftplus,wp-optimize,smush,' \
+          'redirection,w3-total-cache,loginizer,limit-login-attempts-reloaded'
+      end
+
+      it 'should not raise Errno::ENAMETOOLONG' do
+        expect { opt.validate(long_list) }.not_to raise_error
+      end
+
+      it 'returns the expected array' do
+        expected = %w[
+          wordpress-seo jetpack contact-form-7 woocommerce elementor wordfence wp-super-cache
+          wp-mail-smtp duplicate-post classic-editor akismet google-analytics-for-wordpress
+          all-in-one-seo-pack really-simple-ssl wpforms-lite updraftplus wp-optimize smush
+          redirection w3-total-cache loginizer limit-login-attempts-reloaded
+        ]
+        expect(opt.validate(long_list)).to eql expected
+      end
+    end
   end
 end


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Fixes #1801

## Proposed changes

* Modified `OptSmartList#validate` to rescue `Errno::ENAMETOOLONG` in addition to `Errno::ENOENT`
* Added test coverage for long comma-separated lists (>256 characters)

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When users provide a long comma-separated list via options that use `OptSmartList` (`--plugins-list`, `--themes-list`, `--users-list`, or `--usernames`), the validator attempts to determine whether the value is a file path or a comma-separated string by trying to open it as a file first.

On most systems, file paths have a maximum length limit (typically 255-256 characters). When the comma-separated list exceeds this limit, `File.open()` raises `Errno::ENAMETOOLONG` instead of `Errno::ENOENT` (file not found). The original code only caught `Errno::ENOENT`, causing the scan to abort with an unhelpful "File name too long" error.

This fix ensures that long comma-separated lists are properly handled by falling back to the array parsing logic when either exception occurs. This affects all four options that use `OptSmartList`.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Trust the CI, or:

**Before the fix:**
```bash
bundle exec ruby -Ilib bin/wpscan --url http://example.com \
  --plugins-list=wordpress-seo,jetpack,contact-form-7,woocommerce,elementor,wordfence,wp-super-cache,wp-mail-smtp,duplicate-post,classic-editor,akismet,google-analytics-for-wordpress,all-in-one-seo-pack,really-simple-ssl,wpforms-lite,updraftplus,wp-optimize,smush,redirection,w3-total-cache,loginizer,limit-login-attempts-reloaded
```
Expected error: `Scan Aborted: --plugins-list File name too long @ rb_sysopen`

(The list is 313 characters, which exceeds most filesystems' path length limit of 255-256 characters)

**After the fix:**
The same command should work without errors (the scan will continue and only fail if the target is not a WordPress site).