### PR TITLE
Improve threshold error messages to mention threshold options

### DIFF
--- a/lib/wpscan/errors/enumeration.rb
+++ b/lib/wpscan/errors/enumeration.rb
@@ -5,16 +5,16 @@ module WPScan
     class PluginsThresholdReached < Standard
       def to_s
         "The number of plugins detected reached the threshold of #{ParsedCli.plugins_threshold} " \
-          'which might indicate False Positive. It would be recommended to use the --exclude-content-based ' \
-          'option to ignore the bad responses.'
+          'which might indicate False Positive. You can use --plugins-threshold to increase or disable ' \
+          'this limit (set to 0 to disable), or use --exclude-content-based to ignore bad responses.'
       end
     end
 
     class ThemesThresholdReached < Standard
       def to_s
         "The number of themes detected reached the threshold of #{ParsedCli.themes_threshold} " \
-          'which might indicate False Positive. It would be recommended to use the --exclude-content-based ' \
-          'option to ignore the bad responses.'
+          'which might indicate False Positive. You can use --themes-threshold to increase or disable ' \
+          'this limit (set to 0 to disable), or use --exclude-content-based to ignore bad responses.'
       end
     end
   end


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Fixes https://github.com/wpscanteam/wpscan/issues/1862

## Proposed changes

* Updated `PluginsThresholdReached` error message to mention `--plugins-threshold` option
* Updated `ThemesThresholdReached` error message to mention `--themes-threshold` option
* Both error messages now clearly state that setting the threshold to 0 disables the limit

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When users hit the plugins or themes detection threshold (default: 100), they receive an error message that only suggests using `--exclude-content-based` to ignore bad responses. This is misleading because:

1. Users may already be using `--exclude-content-based` (as in the reported issue)
2. The actual solution is to use `--plugins-threshold` or `--themes-threshold` to increase or disable the limit
3. This option exists but is only shown in extended help (`--hh`), making it hard to discover

Sites with legitimately many plugins are currently blocked from scanning without knowing the proper workaround. This change makes the solution discoverable directly in the error message.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Since we are only updating documentation, I'd suggest just proofreading the changes.