### PR TITLE
Improve error message when the database update fails.

### DIFF
--- a/app/controllers/core.rb
+++ b/app/controllers/core.rb
@@ -143,10 +143,17 @@ module WPScan
       end
 
       def update_db
+        @updating_db = true
         output('db_update_started')
         output('db_update_finished', updated: local_db.update, verbose: ParsedCli.verbose)
+        @updating_db = false
 
         exit(0) unless ParsedCli.url
+      end
+
+      # @return [ Boolean ] Whether the DB update is currently in progress
+      def updating_db?
+        @updating_db
       end
 
       # Raises errors if the target is hosted on wordpress.com or is not running WordPress.

--- a/app/views/cli/update_aborted.erb
+++ b/app/views/cli/update_aborted.erb
@@ -1,0 +1,5 @@
+
+Update Aborted: <%= @reason %>
+<% if @verbose -%>
+Trace: <%= @trace.join("\n") %>
+<% end %>

--- a/app/views/json/update_aborted.erb
+++ b/app/views/json/update_aborted.erb
@@ -1,0 +1,5 @@
+"update_aborted": <%= @reason.to_json %>,
+"target_url": <%= @url.to_json %>,
+<% if @verbose -%>
+"trace": <%= @trace.to_json %>,
+<% end %>

--- a/lib/wpscan/scan.rb
+++ b/lib/wpscan/scan.rb
@@ -37,7 +37,7 @@ module WPScan
 
       output_params[:url] = controllers.first.target.url if WPScan::ParsedCli.url
 
-      formatter.output('@scan_aborted', output_params)
+      formatter.output(aborted_view, output_params)
     ensure
       formatter.beautify
     end
@@ -46,6 +46,12 @@ module WPScan
     # @See Formatter
     def formatter
       controllers.first.formatter
+    end
+
+    # @return [ String ] The global view to render when the run is aborted
+    def aborted_view
+      core = controllers.first
+      core.respond_to?(:updating_db?) && core.updating_db? ? '@update_aborted' : '@scan_aborted'
     end
 
     # @return [ Hash ]

--- a/spec/lib/scan_spec.rb
+++ b/spec/lib/scan_spec.rb
@@ -57,6 +57,22 @@ describe WPScan::Scan do
       end
     end
 
+    context 'when an error is raised while updating the database' do
+      it 'aborts with the @update_aborted view' do
+        expect(scanner.controllers.option_parser).to receive(:results).and_return({ url: target_url })
+
+        expect(scanner.controllers.first).to receive(:before_scan) do
+          scanner.controllers.first.instance_variable_set(:@updating_db, true)
+          raise 'connection failed'
+        end
+
+        expect(scanner.formatter).to receive(:output).with(
+          '@update_aborted',
+          { reason: 'connection failed', trace: anything, verbose: true, url: target_url }
+        )
+      end
+    end
+
     context 'when an Interrupt is raised during the scan' do
       it 'aborts the scan with the correct output' do
         expect(scanner.controllers.option_parser).to receive(:results).and_return({ url: target_url })


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Resolves https://github.com/wpscanteam/wpscan/issues/1468

## Proposed changes

* When updating the database errors out, say `Update Aborted` instead of `Scan Aborted`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* So it becomes more clear what exactly failed.
* Just because we are feeling pedantic today 🙂 

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The update breaking is easily triggerable by configuring a proxy that does not exist, i.e. add `--proxy http://localhost:99999` together with `--update` as a parameter and you should see this:

```
Update Aborted: Unable to get https://data.wpscan.org/metadata.json.sha512 (Couldn't resolve proxy name)
```

Removing the `--update`, the normal `Scan Aborted` should show up.


