### PR TITLE
Documented how to cache the database files local if you are using docker, so you don't need to run --update every time you run it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,28 @@ Pull the repo with ```docker pull wpscanteam/wpscan```
 Enumerating usernames
 
 ```shell
-docker run -it --rm wpscanteam/wpscan --url https://target.tld/ --enumerate u
+docker run -it --rm -v wpscan-db:/wpscan/.cache/wpscan/db wpscanteam/wpscan --url https://target.tld/ --enumerate u
 ```
 
 Enumerating a range of usernames
 
 ```shell
-docker run -it --rm wpscanteam/wpscan --url https://target.tld/ --enumerate u1-100
+docker run -it --rm -v wpscan-db:/wpscan/.cache/wpscan/db wpscanteam/wpscan --url https://target.tld/ --enumerate u1-100
 ```
 
 ** replace u1-100 with a range of your choice.
+
+## Persisting the local database
+
+The image ships with a copy of the local database baked in at build time. Because the example commands above use `--rm`, any database update performed during a run is discarded when the container exits, so the next run starts again from the (potentially stale) baked-in copy.
+
+Mounting a named volume at `/wpscan/.cache/wpscan/db` (the `wpscan` user's cache directory inside the container) keeps the database across runs, so `wpscan --update` only re-downloads files whose checksums actually changed and the 5-day staleness prompt behaves as it would for a local install:
+
+```shell
+docker run -it --rm -v wpscan-db:/wpscan/.cache/wpscan/db wpscanteam/wpscan --update
+```
+
+The named volume is created automatically on first use if it doesn't already exist.
 
 # Usage
 


### PR DESCRIPTION
Related to https://github.com/wpscanteam/wpscan/pull/1962

## Proposed changes

* Document how to use a volume properly if you want to run it with a local Docker image.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*  Since we disabled the daily Docker builds for the `latest` tag in https://github.com/wpscanteam/wpscan/pull/1962 the database is not updated regularly in that image anymore.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Since [the introduction XDG support](https://github.com/wpscanteam/wpscan/pull/1974) the default cache dir changed (still respecting the legacy one), which means you'll have to build the image locally and test with that if you want to.


