### PR TITLE
Added SARIF output format.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,7 @@ Metrics/ClassLength:
   Max: 150
   Exclude:
   - 'app/controllers/enumeration/cli_options.rb'
+  - 'app/formatters/sarif.rb'
 Metrics/CyclomaticComplexity:
   Max: 10
 Metrics/MethodLength:

--- a/app/app.rb
+++ b/app/app.rb
@@ -5,6 +5,7 @@ require_relative 'formatters/cli'
 require_relative 'formatters/cli_no_colour'
 require_relative 'formatters/cli_no_color'
 require_relative 'formatters/json'
+require_relative 'formatters/sarif'
 
 # Base controllers
 require_relative 'controllers/core'

--- a/app/formatters/sarif.rb
+++ b/app/formatters/sarif.rb
@@ -1,0 +1,279 @@
+# frozen_string_literal: true
+
+require 'digest'
+
+module WPScan
+  module Formatter
+    # SARIF v2.1.0 Formatter.
+    #
+    # Emits scan results in SARIF v2.1.0 format so they can be consumed by
+    # static-analysis aggregators such as GitHub Code Scanning. WPScan is a
+    # DAST tool, so findings don't have a source file + line; we follow the
+    # mapping discussed on issue #1879:
+    #
+    #   * `result.locations[].physicalLocation.artifactLocation.uri` carries
+    #     the URL where the finding was observed. SARIF explicitly allows
+    #     `uri` to be an absolute URL — see SARIF v2.1.0 §3.4.3
+    #     (https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317419).
+    #   * `result.locations[].logicalLocations[]` carries the WordPress
+    #     component identity (core / plugin <slug> / theme <slug>) decoupled
+    #     from any URL — see SARIF v2.1.0 §3.33
+    #     (https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317719).
+    #
+    # GitHub's guidance on which SARIF fields surface in Code Scanning is
+    # at https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning.
+    #
+    # This formatter inherits from {Json} and reuses the JSON ERB views: the
+    # full scan is buffered as JSON during the run, then transformed into a
+    # SARIF document in {#beautify}. Reusing the JSON layer keeps the SARIF
+    # mapping in one place and lets new JSON fields flow through automatically.
+    class Sarif < Json
+      SARIF_VERSION = '2.1.0'
+      SARIF_SCHEMA  = 'https://json.schemastore.org/sarif-2.1.0.json'
+      INFO_URI      = 'https://wpscan.com/wordpress-security-scanner'
+
+      # Make ERB lookups fall back to the json/* views.
+      def base_format
+        'json'
+      end
+
+      def beautify
+        data = JSON.parse("{#{buffer.chomp.chomp(',')}}")
+        puts JSON.pretty_generate(sarif_document(data))
+      end
+
+      private
+
+      def sarif_document(data)
+        rules   = {}
+        results = []
+
+        collect_vulnerability_results(data, rules, results)
+        collect_interesting_finding_results(data, rules, results)
+
+        {
+          '$schema' => SARIF_SCHEMA,
+          'version' => SARIF_VERSION,
+          'runs' => [build_run(data, rules, results)]
+        }
+      end
+
+      def build_run(data, rules, results)
+        {
+          'tool' => {
+            'driver' => {
+              'name' => 'WPScan',
+              'version' => WPScan::VERSION,
+              'informationUri' => INFO_URI,
+              'rules' => rules.values
+            }
+          },
+          'invocations' => [invocation(data)].compact,
+          'results' => results,
+          'properties' => run_properties(data)
+        }.compact
+      end
+
+      def collect_vulnerability_results(data, rules, results)
+        components(data).each do |component|
+          Array(component[:vulnerabilities]).each do |vuln|
+            rule_id = rule_id_for(vuln)
+            rules[rule_id] ||= rule_for(vuln, rule_id)
+            results << vulnerability_result(vuln, rule_id, component)
+          end
+        end
+      end
+
+      def collect_interesting_finding_results(data, rules, results)
+        Array(data['interesting_findings']).each do |finding|
+          rule_id = "wpscan.interesting-finding.#{finding['type'] || 'unknown'}"
+          rules[rule_id] ||= interesting_finding_rule(rule_id, finding)
+          results << interesting_finding_result(finding, rule_id)
+        end
+      end
+
+      # @return [ Array<Hash> ] one entry per WordPress component observed
+      def components(data)
+        list = []
+        list << core_component(data) if data['version']
+        list << theme_component(data['main_theme']) if data['main_theme']
+        (data['themes'] || {}).each_value { |theme| list << theme_component(theme) }
+        (data['plugins'] || {}).each { |slug, plugin| list << plugin_component(slug, plugin) }
+        list
+      end
+
+      def core_component(data)
+        {
+          kind: 'core',
+          slug: nil,
+          version: data['version']['number'],
+          url: data['effective_url'] || data['target_url'],
+          vulnerabilities: data['version']['vulnerabilities']
+        }
+      end
+
+      def plugin_component(slug, plugin)
+        {
+          kind: 'plugin',
+          slug: slug,
+          version: plugin.dig('version', 'number'),
+          url: plugin['location'],
+          vulnerabilities: plugin['vulnerabilities']
+        }
+      end
+
+      def theme_component(theme)
+        {
+          kind: 'theme',
+          slug: theme['slug'],
+          version: theme.dig('version', 'number'),
+          url: theme['location'],
+          vulnerabilities: theme['vulnerabilities']
+        }
+      end
+
+      def rule_id_for(vuln)
+        cve = Array(vuln.dig('references', 'cve')).first
+        return "CVE-#{cve}" if cve
+
+        wpvulndb = Array(vuln.dig('references', 'wpvulndb')).first
+        return "WPVULNDB-#{wpvulndb}" if wpvulndb
+
+        # Stable fallback so we don't emit duplicate rule entries for the same title.
+        "wpscan.vuln.#{Digest::SHA1.hexdigest(vuln['title'].to_s)[0, 12]}"
+      end
+
+      def rule_for(vuln, rule_id)
+        {
+          'id' => rule_id,
+          'name' => rule_id.gsub(/[^A-Za-z0-9_]/, '_'),
+          'shortDescription' => { 'text' => vuln['title'].to_s },
+          'fullDescription' => { 'text' => vuln['title'].to_s },
+          'helpUri' => help_uri_for(vuln),
+          'defaultConfiguration' => { 'level' => level_for(vuln) },
+          'properties' => rule_properties(vuln)
+        }.compact
+      end
+
+      def vulnerability_result(vuln, rule_id, component)
+        {
+          'ruleId' => rule_id,
+          'level' => level_for(vuln),
+          'message' => { 'text' => vuln_message(vuln, component) },
+          'locations' => [location_for(component[:url], logical_location(component))]
+        }
+      end
+
+      def interesting_finding_rule(rule_id, finding)
+        {
+          'id' => rule_id,
+          'name' => rule_id.gsub(/[^A-Za-z0-9_]/, '_'),
+          'shortDescription' => { 'text' => "Interesting finding: #{finding['type']}" },
+          # Non-vulnerability findings (enumeration results, headers, robots.txt entries,
+          # etc.) are emitted at `note` level so they don't drown out real vulnerabilities
+          # in Code Scanning's UI — see GitHub's SARIF support guidance.
+          'defaultConfiguration' => { 'level' => 'note' },
+          'helpUri' => INFO_URI
+        }
+      end
+
+      def interesting_finding_result(finding, rule_id)
+        location = location_for(finding['url'], nil)
+        {
+          'ruleId' => rule_id,
+          'level' => 'note',
+          'message' => { 'text' => finding['to_s'].to_s },
+          'locations' => location ? [location] : []
+        }
+      end
+
+      def location_for(url, logical)
+        physical = physical_location(url)
+        return nil if physical.nil? && logical.nil?
+
+        loc = {}
+        loc['physicalLocation'] = physical if physical
+        loc['logicalLocations'] = [logical] if logical
+        loc
+      end
+
+      def physical_location(url)
+        return nil if url.nil? || url.to_s.empty?
+
+        { 'artifactLocation' => { 'uri' => url.to_s } }
+      end
+
+      def logical_location(component)
+        fqn = case component[:kind]
+              when 'core'   then "wordpress.core@#{component[:version] || 'unknown'}"
+              when 'theme'  then "wordpress.theme.#{component[:slug]}@#{component[:version] || 'unknown'}"
+              when 'plugin' then "wordpress.plugin.#{component[:slug]}@#{component[:version] || 'unknown'}"
+              end
+
+        {
+          'name' => component[:slug] || component[:kind],
+          'fullyQualifiedName' => fqn,
+          'kind' => 'module'
+        }
+      end
+
+      # Map CVSS v3 base score to a SARIF level. Vulnerabilities without a
+      # score default to `error` since WPScan only flags entries the WPScan
+      # vulnerability database considers exploitable.
+      def level_for(vuln)
+        score = vuln.dig('cvss', 'score').to_f
+        return 'error'   if score >= 7.0
+        return 'warning' if score >= 4.0
+        return 'note'    if score.positive?
+
+        'error'
+      end
+
+      def vuln_message(vuln, component)
+        prefix = case component[:kind]
+                 when 'core'   then "WordPress core #{component[:version]}"
+                 when 'theme'  then "Theme '#{component[:slug]}' #{component[:version]}"
+                 when 'plugin' then "Plugin '#{component[:slug]}' #{component[:version]}"
+                 end
+        suffix = vuln['fixed_in'] ? " (fixed in #{vuln['fixed_in']})" : ' (no fix available)'
+        "#{prefix}: #{vuln['title']}#{suffix}"
+      end
+
+      def help_uri_for(vuln)
+        wpvulndb = Array(vuln.dig('references', 'wpvulndb')).first
+        return "https://wpscan.com/vulnerability/#{wpvulndb}" if wpvulndb
+
+        Array(vuln.dig('references', 'url')).first
+      end
+
+      def rule_properties(vuln)
+        props = {}
+        props['cvss'] = vuln['cvss'] if vuln['cvss']
+        props['references'] = vuln['references'] if vuln['references'] && !vuln['references'].empty?
+        props['fixed_in'] = vuln['fixed_in'] if vuln['fixed_in']
+        props.empty? ? nil : props
+      end
+
+      def invocation(data)
+        inv = { 'executionSuccessful' => true }
+        inv['startTimeUtc'] = to_iso8601(data['start_time']) if data['start_time']
+        inv['endTimeUtc']   = to_iso8601(data['stop_time'])  if data['stop_time']
+        inv
+      end
+
+      def run_properties(data)
+        props = {}
+        props['targetUrl']    = data['target_url']    if data['target_url']
+        props['effectiveUrl'] = data['effective_url'] if data['effective_url']
+        props['targetIp']     = data['target_ip']     if data['target_ip']
+        props.empty? ? nil : props
+      end
+
+      def to_iso8601(epoch)
+        return nil if epoch.nil? || epoch.to_i.zero?
+
+        Time.at(epoch.to_i).utc.strftime('%Y-%m-%dT%H:%M:%S.000Z')
+      end
+    end
+  end
+end

--- a/app/formatters/sarif.rb
+++ b/app/formatters/sarif.rb
@@ -144,13 +144,21 @@ module WPScan
       end
 
       def rule_for(vuln, rule_id)
+        title = vuln['title'].to_s
         {
           'id' => rule_id,
           'name' => rule_id.gsub(/[^A-Za-z0-9_]/, '_'),
-          'shortDescription' => { 'text' => vuln['title'].to_s },
-          'fullDescription' => { 'text' => vuln['title'].to_s },
+          'shortDescription' => { 'text' => title },
+          'fullDescription' => { 'text' => title },
           'helpUri' => help_uri_for(vuln),
           'defaultConfiguration' => { 'level' => level_for(vuln) },
+          'messageStrings' => {
+            # {0} = component label (e.g. "Plugin 'foo' 1.2.3"), {1} = fix status.
+            # Title is baked in here so the rule owns its phrasing and the result
+            # message stays small (SARIF2002). Dynamic args are single-quoted per
+            # SARIF2015 and the message terminates with a period per SARIF2001.
+            'default' => { 'text' => "'{0}': #{title} ('{1}')." }
+          },
           'properties' => rule_properties(vuln)
         }.compact
       end
@@ -159,7 +167,10 @@ module WPScan
         {
           'ruleId' => rule_id,
           'level' => level_for(vuln),
-          'message' => { 'text' => vuln_message(vuln, component) },
+          'message' => {
+            'id' => 'default',
+            'arguments' => [component_label(component), fix_status(vuln)]
+          },
           'locations' => [location_for(component[:url], logical_location(component))]
         }
       end
@@ -173,16 +184,32 @@ module WPScan
           # etc.) are emitted at `note` level so they don't drown out real vulnerabilities
           # in Code Scanning's UI — see GitHub's SARIF support guidance.
           'defaultConfiguration' => { 'level' => 'note' },
+          'messageStrings' => {
+            # {0} = finding header (to_s), {1} = interesting entries joined,
+            # {2} = found-by strategy, {3} = confidence percentage.
+            'default' => {
+              'text' => "'{0}' — entries: '{1}'; found by: '{2}'; confidence: '{3}'."
+            }
+          },
           'helpUri' => INFO_URI
         }
       end
 
       def interesting_finding_result(finding, rule_id)
         location = location_for(finding['url'], nil)
+        entries = Array(finding['interesting_entries']).join(' | ')
         {
           'ruleId' => rule_id,
           'level' => 'note',
-          'message' => { 'text' => finding['to_s'].to_s },
+          'message' => {
+            'id' => 'default',
+            'arguments' => [
+              finding['to_s'].to_s,
+              entries,
+              finding['found_by'].to_s,
+              finding['confidence'].to_s
+            ]
+          },
           'locations' => location ? [location] : []
         }
       end
@@ -229,14 +256,16 @@ module WPScan
         'error'
       end
 
-      def vuln_message(vuln, component)
-        prefix = case component[:kind]
-                 when 'core'   then "WordPress core #{component[:version]}"
-                 when 'theme'  then "Theme '#{component[:slug]}' #{component[:version]}"
-                 when 'plugin' then "Plugin '#{component[:slug]}' #{component[:version]}"
-                 end
-        suffix = vuln['fixed_in'] ? " (fixed in #{vuln['fixed_in']})" : ' (no fix available)'
-        "#{prefix}: #{vuln['title']}#{suffix}"
+      def component_label(component)
+        case component[:kind]
+        when 'core'   then "WordPress core #{component[:version]}"
+        when 'theme'  then "Theme '#{component[:slug]}' #{component[:version]}"
+        when 'plugin' then "Plugin '#{component[:slug]}' #{component[:version]}"
+        end
+      end
+
+      def fix_status(vuln)
+        vuln['fixed_in'] ? "fixed in #{vuln['fixed_in']}" : 'no fix available'
       end
 
       def help_uri_for(vuln)

--- a/spec/app/formatters/sarif_spec.rb
+++ b/spec/app/formatters/sarif_spec.rb
@@ -52,11 +52,17 @@ describe WPScan::Formatter::Sarif do
       rules = doc['runs'].first['tool']['driver']['rules']
       expect(rules.map { |r| r['id'] }).to include 'CVE-2024-12345'
 
+      rule = rules.find { |r| r['id'] == 'CVE-2024-12345' }
+      expect(rule['messageStrings']['default']['text']).to include 'Foo plugin XSS'
+      expect(rule['messageStrings']['default']['text']).to include '{0}'
+      expect(rule['messageStrings']['default']['text']).to include '{1}'
+
       result = doc['runs'].first['results'].first
       expect(result['ruleId']).to eq 'CVE-2024-12345'
       expect(result['level']).to eq 'error'
-      expect(result['message']['text']).to include 'Foo plugin XSS'
-      expect(result['message']['text']).to include 'fixed in 1.2.4'
+      expect(result['message']['text']).to be_nil
+      expect(result['message']['id']).to eq 'default'
+      expect(result['message']['arguments']).to eq ["Plugin 'foo' 1.2.3", 'fixed in 1.2.4']
 
       loc = result['locations'].first
       expect(loc['physicalLocation']['artifactLocation']['uri']).to eq 'https://target.example/wp-content/plugins/foo/'
@@ -71,6 +77,9 @@ describe WPScan::Formatter::Sarif do
             'url' => 'https://target.example/robots.txt',
             'to_s' => 'robots.txt found: ...',
             'type' => 'robots_txt',
+            'found_by' => 'Direct Access (Aggressive Detection)',
+            'confidence' => 100,
+            'interesting_entries' => ['Disallow: /wp-admin/'],
             'references' => {}
           }
         ]
@@ -82,6 +91,13 @@ describe WPScan::Formatter::Sarif do
       result = doc['runs'].first['results'].first
       expect(result['level']).to eq 'note'
       expect(result['ruleId']).to eq 'wpscan.interesting-finding.robots_txt'
+      expect(result['message']['id']).to eq 'default'
+      expect(result['message']['arguments']).to eq [
+        'robots.txt found: ...',
+        'Disallow: /wp-admin/',
+        'Direct Access (Aggressive Detection)',
+        '100'
+      ]
       expect(result['locations'].first['physicalLocation']['artifactLocation']['uri']).to eq 'https://target.example/robots.txt'
     end
 

--- a/spec/app/formatters/sarif_spec.rb
+++ b/spec/app/formatters/sarif_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+describe WPScan::Formatter::Sarif do
+  subject(:formatter) { described_class.new }
+
+  before { formatter.views_directories << FIXTURES_VIEWS }
+
+  its(:format)            { should eq 'sarif' }
+  its(:base_format)       { should eq 'json' }
+  its(:user_interaction?) { should be false }
+
+  describe '#beautify' do
+    def fill_buffer(json_hash)
+      # Simulate the JSON formatter's per-key buffer fragments.
+      json_hash.each do |k, v|
+        formatter.buffer << "#{k.to_json}: #{v.to_json},\n"
+      end
+    end
+
+    it 'wraps an empty buffer in a valid SARIF skeleton' do
+      formatter.buffer << ''
+      expect { formatter.beautify }.to output(/"version": "2.1.0"/).to_stdout
+    end
+
+    it 'emits a SARIF result for a plugin vulnerability' do
+      fill_buffer(
+        'target_url' => 'https://target.example/',
+        'effective_url' => 'https://target.example/',
+        'plugins' => {
+          'foo' => {
+            'slug' => 'foo',
+            'location' => 'https://target.example/wp-content/plugins/foo/',
+            'version' => { 'number' => '1.2.3' },
+            'vulnerabilities' => [
+              {
+                'title' => 'Foo plugin XSS',
+                'fixed_in' => '1.2.4',
+                'cvss' => { 'score' => '7.5', 'vector' => 'AV:N/AC:L/Au:N/C:P/I:P/A:P' },
+                'references' => { 'cve' => ['2024-12345'], 'wpvulndb' => ['abc'] }
+              }
+            ]
+          }
+        }
+      )
+
+      output = capture_stdout { formatter.beautify }
+      doc = JSON.parse(output)
+
+      expect(doc['version']).to eq '2.1.0'
+      expect(doc['runs'].first['tool']['driver']['name']).to eq 'WPScan'
+
+      rules = doc['runs'].first['tool']['driver']['rules']
+      expect(rules.map { |r| r['id'] }).to include 'CVE-2024-12345'
+
+      result = doc['runs'].first['results'].first
+      expect(result['ruleId']).to eq 'CVE-2024-12345'
+      expect(result['level']).to eq 'error'
+      expect(result['message']['text']).to include 'Foo plugin XSS'
+      expect(result['message']['text']).to include 'fixed in 1.2.4'
+
+      loc = result['locations'].first
+      expect(loc['physicalLocation']['artifactLocation']['uri']).to eq 'https://target.example/wp-content/plugins/foo/'
+      expect(loc['logicalLocations'].first['fullyQualifiedName']).to eq 'wordpress.plugin.foo@1.2.3'
+      expect(loc['logicalLocations'].first['kind']).to eq 'module'
+    end
+
+    it 'emits interesting findings at note level' do
+      fill_buffer(
+        'interesting_findings' => [
+          {
+            'url' => 'https://target.example/robots.txt',
+            'to_s' => 'robots.txt found: ...',
+            'type' => 'robots_txt',
+            'references' => {}
+          }
+        ]
+      )
+
+      output = capture_stdout { formatter.beautify }
+      doc = JSON.parse(output)
+
+      result = doc['runs'].first['results'].first
+      expect(result['level']).to eq 'note'
+      expect(result['ruleId']).to eq 'wpscan.interesting-finding.robots_txt'
+      expect(result['locations'].first['physicalLocation']['artifactLocation']['uri']).to eq 'https://target.example/robots.txt'
+    end
+
+    it 'maps cvss score to level' do
+      formatter.send(:level_for, 'cvss' => { 'score' => '9.8' }).tap { |l| expect(l).to eq 'error' }
+      formatter.send(:level_for, 'cvss' => { 'score' => '5.0' }).tap { |l| expect(l).to eq 'warning' }
+      formatter.send(:level_for, 'cvss' => { 'score' => '2.1' }).tap { |l| expect(l).to eq 'note' }
+      formatter.send(:level_for, {}).tap { |l| expect(l).to eq 'error' }
+    end
+
+    def capture_stdout
+      old = $stdout
+      $stdout = StringIO.new
+      yield
+      $stdout.string
+    ensure
+      $stdout = old
+    end
+  end
+end

--- a/spec/shared_examples/formatter_class_methods.rb
+++ b/spec/shared_examples/formatter_class_methods.rb
@@ -21,7 +21,7 @@ shared_examples WPScan::Formatter::ClassMethods do
 
   describe '#availables' do
     it 'returns the right list' do
-      expect(subject.availables).to match_array(%w[json cli-no-colour cli-no-color cli])
+      expect(subject.availables).to match_array(%w[json sarif cli-no-colour cli-no-color cli])
     end
   end
 end


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Resolves https://github.com/wpscanteam/wpscan/issues/1879 


## Proposed changes

  * Added a new SARIF v2.1.0 output format (`--format sarif`).
  * Each WordPress component (core, themes, plugins) is represented as a logical location alongside the URL where it was observed, so consumers can tell findings apart.
  * Vulnerability severity is mapped from CVSS score to SARIF level (`error` / `warning` / `note`), and interesting findings are emitted at `note` level.
  * Messages are structured per the SARIF spec's recommendations: rules own the message template, results reference it by id and pass dynamic values as arguments, dynamic content is single-quoted, and templates end with a period.
  * Interesting-finding messages carry the supporting context (entries, detection method, confidence) so the SARIF view is roughly informative as the terminal output.

  ## Why are these changes being made?

  * SARIF is the standard interchange format for static-analysis output and is consumed by aggregators like GitHub Code Scanning. Adding it lets WPScan results flow into existing security dashboards and review pipelines without bespoke glue.

  ## Testing instructions

  * Run a real scan with `--format sarif -o out.sarif.json` and skim the file: it should validate as SARIF 2.1.0, contain rules with message templates, results that reference them by id with arguments, logical locations identifying the affected WordPress component, and severity levels derived from CVSS.
* You can validate the file over at https://sarifweb.azurewebsites.net/Validation

