### PR TITLE
Fix crash when WPScan API returns HTML instead of JSON

### DIFF
--- a/app/views/cli/vuln_api/status.erb
+++ b/app/views/cli/vuln_api/status.erb
@@ -1,6 +1,8 @@
 <% unless @status.empty? -%>
 <% if @status['http_error'] -%>
 <%= critical_icon %> WPScan DB API, <%= @status['http_error'].to_s %>
+<% elsif @status['parse_error'] -%>
+<%= critical_icon %> WPScan DB API returned an invalid response. Please check your network/proxy configuration or try again later.
 <% else -%>
 <%= info_icon %> WPScan DB API OK
  | Plan: <%= @status['plan'] %>

--- a/app/views/json/vuln_api/status.erb
+++ b/app/views/json/vuln_api/status.erb
@@ -2,6 +2,8 @@
 <% unless @status.empty? -%>
 <% if @status['http_error'] -%>
 "http_error": <%= @status['http_error'].to_s.to_json %>
+<% elsif @status['parse_error'] -%>
+"parse_error": "WPScan DB API returned an invalid response. Please check your network/proxy configuration or try again later."
 <% else -%>
 "plan": <%= @status['plan'].to_json %>,
 "requests_done_during_scan": <%= @api_requests.to_json %>,

--- a/lib/wpscan/db/vuln_api.rb
+++ b/lib/wpscan/db/vuln_api.rb
@@ -41,6 +41,9 @@ module WPScan
         end
 
         { 'http_error' => e }
+      rescue JSON::ParserError => e
+        # API returned non-JSON response (HTML, plain text, etc.)
+        { 'parse_error' => e }
       end
 
       # @return [ Hash ]

--- a/spec/lib/db/vuln_api_spec.rb
+++ b/spec/lib/db/vuln_api_spec.rb
@@ -101,6 +101,28 @@ describe WPScan::DB::VulnApi do
             expect(api.get(path)).to eql({})
           end
         end
+
+        context 'when 200 with HTML body (browser check, proxy, etc.)' do
+          let(:code) { 200 }
+          let(:body) { '<!DOCTYPE html><html><body>Browser check</body></html>' }
+
+          it 'returns a hash with parse_error' do
+            result = api.get(path)
+            expect(result).to have_key('parse_error')
+            expect(result['parse_error']).to be_a(JSON::ParserError)
+          end
+        end
+
+        context 'when 403 with HTML body' do
+          let(:code) { 403 }
+          let(:body) { '<html><body>Forbidden</body></html>' }
+
+          it 'returns a hash with parse_error' do
+            result = api.get(path)
+            expect(result).to have_key('parse_error')
+            expect(result['parse_error']).to be_a(JSON::ParserError)
+          end
+        end
       end
 
       context 'when timeouts' do


### PR DESCRIPTION
Fixes #1732

## Proposed changes

* Added `rescue JSON::ParserError` to `VulnApi.get` method to handle non-JSON responses
* Return `{ 'parse_error' => e }` instead of crashing when API returns HTML
* Updated CLI and JSON output templates to display appropriate error message
* Added test coverage for HTML response scenarios (200 and 403 status codes)

| Before | After |
|---|---|
| <img width="2156" height="1128" alt="CleanShot 2026-04-30 at 12 24 07@2x" src="https://github.com/user-attachments/assets/da148bd1-b75b-48df-80b4-de7d8b9b7857" /> | <img width="1838" height="364" alt="CleanShot 2026-04-30 at 12 24 37@2x" src="https://github.com/user-attachments/assets/299e7af0-9fe5-4e9b-a278-249632726fac" /> |

## Why are these changes being made?

Users experience scan aborts with `lexical error: invalid char in json text` when the WPScan API returns HTML instead of JSON. This could happen due to network issues.

The current code only catches `Error::HTTP` exceptions but not `JSON::ParserError`, causing the scan to abort completely. This fix ensures scans continue gracefully when the API returns invalid responses, consistent with how 404/429 errors are already handled.

The fix improves user experience by:
- Preventing complete scan failure from temporary API issues
- Providing a clear, actionable error message instead of a cryptic JSON parsing error
- Allowing scans to continue and collect other data even if the API is unreachable

## Testing instructions

Trust the CI