### PR TITLE
Raise error when enumerating vulnerable plugins/themes without API token

### DIFF
--- a/app/controllers/enumeration.rb
+++ b/app/controllers/enumeration.rb
@@ -7,6 +7,15 @@ module WPScan
   module Controller
     # Enumeration Controller
     class Enumeration < WPScan::Controller::Base
+      def before_scan
+        enum = ParsedCli.enumerate || {}
+
+        # Check if vulnerable plugin/theme enumeration is requested without an API token
+        if (enum[:vulnerable_plugins] || enum[:vulnerable_themes]) && DB::VulnApi.token.nil?
+          raise Error::ApiTokenRequiredForVulnerableEnumeration
+        end
+      end
+
       def run
         enum = ParsedCli.enumerate || {}
 

--- a/app/controllers/enumeration.rb
+++ b/app/controllers/enumeration.rb
@@ -11,9 +11,9 @@ module WPScan
         enum = ParsedCli.enumerate || {}
 
         # Check if vulnerable plugin/theme enumeration is requested without an API token
-        if (enum[:vulnerable_plugins] || enum[:vulnerable_themes]) && DB::VulnApi.token.nil?
-          raise Error::ApiTokenRequiredForVulnerableEnumeration
-        end
+        return unless (enum[:vulnerable_plugins] || enum[:vulnerable_themes]) && DB::VulnApi.token.nil?
+
+        raise Error::ApiTokenRequiredForVulnerableEnumeration
       end
 
       def run

--- a/lib/wpscan/errors/vuln_api.rb
+++ b/lib/wpscan/errors/vuln_api.rb
@@ -16,5 +16,14 @@ module WPScan
         'Your API limit has been reached'
       end
     end
+
+    # Error raised when trying to enumerate vulnerable plugins/themes without an API token
+    class ApiTokenRequiredForVulnerableEnumeration < Standard
+      def to_s
+        'An API token is required for vulnerable plugin/theme enumeration. ' \
+          'You can get a free API token with 25 daily requests by registering at https://wpscan.com/register. ' \
+          'Provide it via --api-token TOKEN or the WPSCAN_API_TOKEN environment variable.'
+      end
+    end
   end
 end

--- a/spec/app/controllers/enumeration_spec.rb
+++ b/spec/app/controllers/enumeration_spec.rb
@@ -81,6 +81,49 @@ describe WPScan::Controller::Enumeration do
     end
   end
 
+  describe '#before_scan' do
+    context 'when enumerating vulnerable plugins without API token' do
+      let(:cli_args) { "#{super()} -e vp" }
+
+      it 'raises ApiTokenRequiredForVulnerableEnumeration error' do
+        expect { controller.before_scan }.to raise_error(WPScan::Error::ApiTokenRequiredForVulnerableEnumeration)
+      end
+    end
+
+    context 'when enumerating vulnerable themes without API token' do
+      let(:cli_args) { "#{super()} -e vt" }
+
+      it 'raises ApiTokenRequiredForVulnerableEnumeration error' do
+        expect { controller.before_scan }.to raise_error(WPScan::Error::ApiTokenRequiredForVulnerableEnumeration)
+      end
+    end
+
+    context 'when enumerating vulnerable plugins with API token' do
+      let(:cli_args) { "#{super()} -e vp --api-token test-token" }
+
+      before do
+        # Simulate the VulnApi controller running before Enumeration
+        vuln_api_controller = WPScan::Controller::VulnApi.new
+        allow(WPScan::DB::VulnApi).to receive(:status).and_return({ 'plan' => 'free', 'requests_remaining' => 25 })
+        vuln_api_controller.before_scan
+      end
+
+      after { WPScan::DB::VulnApi.token = nil }
+
+      it 'does not raise an error' do
+        expect { controller.before_scan }.not_to raise_error
+      end
+    end
+
+    context 'when enumerating non-vulnerable plugins without API token' do
+      let(:cli_args) { "#{super()} -e p" }
+
+      it 'does not raise an error' do
+        expect { controller.before_scan }.not_to raise_error
+      end
+    end
+  end
+
   describe '#enum_users' do
     before { expect(controller.formatter).to receive(:output).twice }
     after { controller.enum_users }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Fixes https://github.com/wpscanteam/wpscan/issues/1564

## Proposed changes

* Add new error class `ApiTokenRequiredForVulnerableEnumeration`
* Add `before_scan` hook in Enumeration controller to validate API token presence before enumeration starts
* Add tests to verify the validation works

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When users run WPScan with `-e vp` (vulnerable plugins) or `-e vt` (vulnerable themes) without providing an API token, the scanner performs the entire enumeration process (which can take several minutes), only to show no results at the end with a warning message about the missing token. This wastes time and resources.

This change validates the API token requirement before enumeration begins, immediately informing users they need a token for vulnerable enumeration. This saves time and provides better user experience by failing fast with a clear, actionable error message.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Trust the CI

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor grants Automattic Inc. the unlimited, non-exclusive right to reuse, modify, and relicense the code.

