### PR TITLE
fix: Use user cache dir for runtime files

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ The database location follows the [XDG Base Directory Specification](https://spe
 - **New installations**: `~/.cache/wpscan/db` (or `$XDG_CACHE_HOME/wpscan/db` if set)
 - **Existing installations**: `~/.wpscan/db` (legacy path, maintained for backward compatibility)
 
+Runtime files such as the default HTTP cache and cookie jar are stored under `$TMPDIR/wpscan` when
+`$TMPDIR` is set. Otherwise they use the same per-user XDG cache directory, for example
+`~/.cache/wpscan/cache` and `~/.cache/wpscan/cookie_jar.txt`. These defaults can be overridden
+with `--cache-dir` and `--cookie-jar`.
+
 To migrate an existing installation to the XDG path:
 
 ```shell

--- a/lib/wpscan.rb
+++ b/lib/wpscan.rb
@@ -87,6 +87,10 @@ module WPScan
       'wpscan'
     end
 
+    def user_cache_dir
+      Pathname.new(ENV['XDG_CACHE_HOME'] || Pathname.new(Dir.home).join('.cache')).join(app_name)
+    end
+
     def cached_requests
       @@cached_requests ||= 0
     end

--- a/lib/wpscan/controller.rb
+++ b/lib/wpscan/controller.rb
@@ -72,7 +72,9 @@ module WPScan
 
       # @return [ String ]
       def tmp_directory
-        File.join(ENV['TMPDIR'] || '/tmp', WPScan.app_name)
+        return Pathname.new(ENV['TMPDIR']).join(WPScan.app_name).to_s if ENV['TMPDIR']
+
+        WPScan.user_cache_dir.to_s
       end
 
       protected

--- a/spec/lib/controller_spec.rb
+++ b/spec/lib/controller_spec.rb
@@ -19,10 +19,29 @@ describe WPScan::Controller do
   its('target.scope.domains') { should eq [PublicSuffix.parse('example.com')] }
 
   describe '#tmp_directory' do
-    context 'when TMPDIR is not set' do
-      before { stub_const('ENV', ENV.to_hash.tap { |e| e.delete('TMPDIR') }) }
+    context 'when TMPDIR and XDG_CACHE_HOME are not set' do
+      before do
+        env = ENV.to_hash
+        env.delete('TMPDIR')
+        env.delete('XDG_CACHE_HOME')
 
-      its(:tmp_directory) { should eql '/tmp/wpscan' }
+        stub_const('ENV', env)
+        allow(Dir).to receive(:home).and_return('/home/user')
+      end
+
+      its(:tmp_directory) { should eql '/home/user/.cache/wpscan' }
+    end
+
+    context 'when TMPDIR is not set and XDG_CACHE_HOME is set' do
+      before do
+        env = ENV.to_hash
+        env.delete('TMPDIR')
+        env['XDG_CACHE_HOME'] = '/home/user/cache'
+
+        stub_const('ENV', env)
+      end
+
+      its(:tmp_directory) { should eql '/home/user/cache/wpscan' }
     end
 
     context 'when TMPDIR is set' do

--- a/spec/lib/wpscan_spec.rb
+++ b/spec/lib/wpscan_spec.rb
@@ -10,4 +10,25 @@ describe WPScan do
       expect(WPScan.app_name).to eql 'wpscan'
     end
   end
+
+  describe '#user_cache_dir' do
+    context 'when XDG_CACHE_HOME is not set' do
+      before do
+        stub_const('ENV', ENV.to_hash.tap { |e| e.delete('XDG_CACHE_HOME') })
+        allow(Dir).to receive(:home).and_return('/home/user')
+      end
+
+      it 'returns the default XDG cache path' do
+        expect(WPScan.user_cache_dir.to_s).to eql '/home/user/.cache/wpscan'
+      end
+    end
+
+    context 'when XDG_CACHE_HOME is set' do
+      before { stub_const('ENV', ENV.to_hash.merge('XDG_CACHE_HOME' => '/home/user/cache')) }
+
+      it 'returns the XDG cache path' do
+        expect(WPScan.user_cache_dir.to_s).to eql '/home/user/cache/wpscan'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Related to #1893

## Proposed changes

* Add a shared `WPScan.user_cache_dir` helper for the per-user XDG cache directory.
* Keep honoring `$TMPDIR` for runtime files when it is explicitly set.
* When `$TMPDIR` is not set, use the per-user XDG cache directory instead of `/tmp/wpscan` for default runtime files such as the HTTP cache and cookie jar.
* Update specs for the default, `$XDG_CACHE_HOME`, and `$TMPDIR` cases.
* Document the runtime file defaults in the README.

## Why are these changes being made?

* The previous fallback to `/tmp/wpscan` used a predictable shared directory on multi-user systems.
* A user-specific cache directory avoids the default symlink/clobbering risk described in #1893 while preserving explicit `--cache-dir`, `--cookie-jar`, and `$TMPDIR` behavior.

## Testing instructions

* Run `bundle exec rspec spec/lib/controller_spec.rb spec/lib/wpscan_spec.rb`.
* Confirm `--cache-dir` and `--cookie-jar` still override the defaults.
* Confirm the default runtime directory is `$TMPDIR/wpscan` when `$TMPDIR` is set.
* Confirm the default runtime directory is `$XDG_CACHE_HOME/wpscan` or `~/.cache/wpscan` when `$TMPDIR` is not set.

Local validation performed:

* `git diff --check`

I could not run the Ruby test suite locally because Ruby is not installed in this workstation environment.

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor grants Automattic Inc. the unlimited, non-exclusive right to reuse, modify, and relicense the code.