### PR TITLE
Add PoC to vulnerability output

### DIFF
--- a/app/formatters/sarif.rb
+++ b/app/formatters/sarif.rb
@@ -280,6 +280,7 @@ module WPScan
         props['cvss'] = vuln['cvss'] if vuln['cvss']
         props['references'] = vuln['references'] if vuln['references'] && !vuln['references'].empty?
         props['fixed_in'] = vuln['fixed_in'] if vuln['fixed_in']
+        props['poc'] = vuln['poc'] if vuln['poc']
         props.empty? ? nil : props
       end
 

--- a/app/views/cli/vulnerability.erb
+++ b/app/views/cli/vulnerability.erb
@@ -5,6 +5,9 @@
 <% if @v.fixed_in -%>
  |     Fixed in: <%= @v.fixed_in %>
 <% end -%>
+<% if @v.poc -%>
+ |     PoC: available
+<% end -%>
 <% unless (references = @v.references_urls).empty? -%>
 <% if references.size == 1 -%>
  |     Reference: <%= references.first %>

--- a/app/views/json/finding.erb
+++ b/app/views/json/finding.erb
@@ -23,6 +23,9 @@
     "cvss": <%= v.cvss.to_json %>,
     <% end -%>
     "fixed_in": <%= v.fixed_in.to_json %>,
+    <% if v.poc -%>
+    "poc": <%= v.poc.to_json %>,
+    <% end -%>
     "references": <%= v.references.to_json %>
   }<% unless index == last_index -%>,<% end -%>
   <% end -%>

--- a/lib/wpscan/vulnerability.rb
+++ b/lib/wpscan/vulnerability.rb
@@ -5,7 +5,7 @@ module WPScan
   class Vulnerability
     include References
 
-    attr_reader :title, :type, :fixed_in, :introduced_in, :cvss
+    attr_reader :title, :type, :fixed_in, :introduced_in, :cvss, :poc
 
     # @param [ String ] title
     # @param [ Hash ] references
@@ -22,12 +22,15 @@ module WPScan
     # @param [ HashSymbol ] cvss
     # @option cvss [ String ] :score
     # @option cvss [ String ] :vector
-    def initialize(title, references: {}, type: nil, fixed_in: nil, introduced_in: nil, cvss: nil)
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(title, references: {}, type: nil, fixed_in: nil, introduced_in: nil, cvss: nil, poc: nil)
+      # rubocop:enable Metrics/ParameterLists
       @title         = title
       @type          = type
       @fixed_in      = fixed_in
       @introduced_in = introduced_in
       @cvss          = { score: cvss[:score], vector: cvss[:vector] } if cvss
+      @poc           = poc
 
       self.references = references
     end
@@ -49,7 +52,8 @@ module WPScan
         type: json_data['vuln_type'],
         fixed_in: json_data['fixed_in'],
         introduced_in: json_data['introduced_in'],
-        cvss: json_data['cvss']&.symbolize_keys
+        cvss: json_data['cvss']&.symbolize_keys,
+        poc: json_data['poc']
       )
     end
 
@@ -61,7 +65,8 @@ module WPScan
         type == other.type &&
         references == other.references &&
         fixed_in == other.fixed_in &&
-        cvss == other.cvss
+        cvss == other.cvss &&
+        poc == other.poc
     end
   end
 end

--- a/spec/app/models/plugin_spec.rb
+++ b/spec/app/models/plugin_spec.rb
@@ -205,7 +205,8 @@ describe WPScan::Model::Plugin do
                 'First Vuln <= 6.3.10 - LFI',
                 references: { wpvulndb: '1' },
                 type: 'LFI',
-                fixed_in: '6.3.10'
+                fixed_in: '6.3.10',
+                poc: "#!/bin/bash\ncurl 'http://example.com/?file=../../../etc/passwd'"
               ),
               WPScan::Vulnerability.new('No Fixed In', references: { wpvulndb: '2' })
             ]

--- a/spec/app/models/theme_spec.rb
+++ b/spec/app/models/theme_spec.rb
@@ -232,7 +232,8 @@ describe WPScan::Model::Theme do
               'First Vuln',
               references: { wpvulndb: '1' },
               type: 'LFI',
-              fixed_in: '6.3.10'
+              fixed_in: '6.3.10',
+              poc: "<?php\n// Theme LFI exploit\ninclude($_GET['page']);\n?>"
             ),
             WPScan::Vulnerability.new('No Fixed In', references: { wpvulndb: '2' })
           ]

--- a/spec/app/models/wp_version_spec.rb
+++ b/spec/app/models/wp_version_spec.rb
@@ -78,7 +78,8 @@ describe WPScan::Model::WpVersion do
               'WP 3.8.1 - Vuln 1',
               references: { wpvulndb: '1' },
               type: 'SQLI',
-              cvss: { score: '5.4', vector: 'VECTOR' }
+              cvss: { score: '5.4', vector: 'VECTOR' },
+              poc: "# Sample exploit code\nprint('exploit')"
             ),
             WPScan::Vulnerability.new(
               'WP 3.8.1 - Vuln 2',

--- a/spec/fixtures/db/vuln_api/plugins/vulnerable-not-popular.json
+++ b/spec/fixtures/db/vuln_api/plugins/vulnerable-not-popular.json
@@ -7,7 +7,8 @@
       "title" : "First Vuln \u003c= 6.3.10 - LFI",
       "fixed_in" : "6.3.10",
       "id" : 1,
-      "vuln_type": "LFI"
+      "vuln_type": "LFI",
+      "poc": "#!/bin/bash\ncurl 'http://example.com/?file=../../../etc/passwd'"
     },
     {
       "title": "No Fixed In",

--- a/spec/fixtures/db/vuln_api/themes/vulnerable-not-popular.json
+++ b/spec/fixtures/db/vuln_api/themes/vulnerable-not-popular.json
@@ -7,7 +7,8 @@
       "title" : "First Vuln",
       "fixed_in" : "6.3.10",
       "id" : 1,
-      "vuln_type": "LFI"
+      "vuln_type": "LFI",
+      "poc": "<?php\n// Theme LFI exploit\ninclude($_GET['page']);\n?>"
     },
     {
       "title": "No Fixed In",

--- a/spec/fixtures/db/vuln_api/wordpresses/381.json
+++ b/spec/fixtures/db/vuln_api/wordpresses/381.json
@@ -13,7 +13,8 @@
       "cvss": {
         "score": "5.4",
         "vector": "VECTOR"
-      }
+      },
+      "poc": "# Sample exploit code\nprint('exploit')"
      },
      {
       "references" : {

--- a/spec/output/wp_version/with_vulns.cli_no_colour
+++ b/spec/output/wp_version/with_vulns.cli_no_colour
@@ -5,6 +5,7 @@
  |
  | [!] Title: WP 3.8.1 - Vuln 1
  |     CVSS: 5.4 (VECTOR)
+ |     PoC: available
  |     Reference: https://wpscan.com/vulnerability/1
  |
  | [!] Title: WP 3.8.1 - Vuln 2

--- a/spec/output/wp_version/with_vulns.json
+++ b/spec/output/wp_version/with_vulns.json
@@ -19,6 +19,7 @@
           "vector": "VECTOR"
         },
         "fixed_in": null,
+        "poc": "# Sample exploit code\nprint('exploit')",
         "references": {
           "wpvulndb": [
             "1"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Fixes https://github.com/wpscanteam/wpscan/issues/1655

## Proposed changes

* Added `poc` field extraction from WPScan API responses to the Vulnerability class
* Display "PoC: available" in CLI output when proof-of-concept exploit code exists. If a PoC is not available, this line will not be printed.
* Include full PoC content in JSON and SARIF output formats for programmatic access
* Updated tests

| Before | After |
|---|---|
| <img width="1684" height="602" alt="CleanShot 2026-05-05 at 16 09 25@2x" src="https://github.com/user-attachments/assets/2b846a11-91a4-4694-8c94-3038582434d3" /> | <img width="1688" height="642" alt="CleanShot 2026-05-05 at 16 07 22@2x" src="https://github.com/user-attachments/assets/614fa5d5-0683-4fc7-9844-38da92d32cf9" /> |

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Feature request: researchers need to quickly identify which vulnerabilities have public proof-of-concept to prioritize remediation. The WPScan API already provides a "poc" field with exploit code, but the CLI wasn't displaying it. This change surfaces that critical information, helping focus on the highest-risk vulnerabilities first.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Trust the CI

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor grants Automattic Inc. the unlimited, non-exclusive right to reuse, modify, and relicense the code.

