### PR TITLE
Made it so that --plugins-list and --themes-list take precedence over their respective -e options for vp/ap/p or vt/at/t.

### DIFF
--- a/app/controllers/enumeration.rb
+++ b/app/controllers/enumeration.rb
@@ -19,6 +19,8 @@ module WPScan
       def run
         enum = ParsedCli.enumerate || {}
 
+        resolve_list_enumerate_collisions(enum)
+
         enum_plugins if enum_plugins?(enum)
         enum_themes  if enum_themes?(enum)
 

--- a/app/controllers/enumeration/cli_options.rb
+++ b/app/controllers/enumeration/cli_options.rb
@@ -15,7 +15,7 @@ module WPScan
         [
           OptMultiChoices.new(
             ['-e', '--enumerate [OPTS]', 'Enumeration Process',
-             'Note: --plugins-list overrides vp/ap/p; --themes-list overrides vt/at/t'
+             'Note: --plugins-list overrides vp/ap/p; --themes-list overrides vt/at/t.'],
             choices: {
               vp: OptBoolean.new(['--vulnerable-plugins']),
               ap: OptBoolean.new(['--all-plugins']),

--- a/app/controllers/enumeration/cli_options.rb
+++ b/app/controllers/enumeration/cli_options.rb
@@ -15,9 +15,7 @@ module WPScan
         [
           OptMultiChoices.new(
             ['-e', '--enumerate [OPTS]', 'Enumeration Process',
-             'Note: vp/ap/p are ignored if --plugins-list is provided, ' \
-             'and vt/at/t are ignored if --themes-list is provided. ' \
-             'A notice is printed when this happens.'],
+             'Note: --plugins-list overrides vp/ap/p; --themes-list overrides vt/at/t'
             choices: {
               vp: OptBoolean.new(['--vulnerable-plugins']),
               ap: OptBoolean.new(['--all-plugins']),

--- a/app/controllers/enumeration/cli_options.rb
+++ b/app/controllers/enumeration/cli_options.rb
@@ -14,7 +14,10 @@ module WPScan
       def cli_enum_choices
         [
           OptMultiChoices.new(
-            ['-e', '--enumerate [OPTS]', 'Enumeration Process'],
+            ['-e', '--enumerate [OPTS]', 'Enumeration Process',
+             'Note: vp/ap/p are ignored if --plugins-list is provided, ' \
+             'and vt/at/t are ignored if --themes-list is provided. ' \
+             'A notice is printed when this happens.'],
             choices: {
               vp: OptBoolean.new(['--vulnerable-plugins']),
               ap: OptBoolean.new(['--all-plugins']),

--- a/app/controllers/enumeration/enum_methods.rb
+++ b/app/controllers/enumeration/enum_methods.rb
@@ -11,9 +11,10 @@ module WPScan
       def enum_message(type, detection_mode)
         return unless %w[plugins themes].include?(type)
 
-        details = if ParsedCli.enumerate[:"vulnerable_#{type}"]
+        enumerate = ParsedCli.enumerate || {}
+        details = if enumerate[:"vulnerable_#{type}"]
                     'Vulnerable'
-                  elsif ParsedCli.enumerate[:"all_#{type}"]
+                  elsif enumerate[:"all_#{type}"]
                     'All'
                   else
                     'Most Popular'
@@ -52,11 +53,37 @@ module WPScan
         }
       end
 
+      # Resolves collisions between --plugins-list/--themes-list and the
+      # corresponding --enumerate choices. The list options take precedence;
+      # colliding enumerate keys are removed from the supplied hash and a
+      # notice is emitted for each ignored choice.
+      #
+      # @param [ Hash ] enum The ParsedCli.enumerate hash (mutated in place)
+      def resolve_list_enumerate_collisions(enum)
+        {
+          plugins_list: %i[vulnerable_plugins all_plugins popular_plugins],
+          themes_list: %i[vulnerable_themes all_themes popular_themes]
+        }.each do |list_opt, enum_keys|
+          next unless ParsedCli.send(list_opt)
+
+          ignored = enum_keys.select { |k| enum.key?(k) }
+          next if ignored.empty?
+
+          ignored.each { |k| enum.delete(k) }
+
+          output(
+            '@notice',
+            msg: "--#{list_opt.to_s.tr('_', '-')} provided; " \
+                 "ignoring colliding --enumerate choice(s): #{ignored.join(', ')}"
+          )
+        end
+      end
+
       # @param [ Hash ] opts
       #
       # @return [ Boolean ] Wether or not to enumerate the plugins
       def enum_plugins?(opts)
-        opts[:popular_plugins] || opts[:all_plugins] || opts[:vulnerable_plugins]
+        ParsedCli.plugins_list || opts[:popular_plugins] || opts[:all_plugins] || opts[:vulnerable_plugins]
       end
 
       def enum_plugins
@@ -78,7 +105,7 @@ module WPScan
 
         plugins.each(&:version)
 
-        plugins.select!(&:vulnerable?) if ParsedCli.enumerate[:vulnerable_plugins]
+        plugins.select!(&:vulnerable?) if ParsedCli.enumerate&.dig(:vulnerable_plugins)
 
         output('plugins', plugins: plugins)
       end
@@ -103,7 +130,7 @@ module WPScan
       #
       # @return [ Boolean ] Wether or not to enumerate the themes
       def enum_themes?(opts)
-        opts[:popular_themes] || opts[:all_themes] || opts[:vulnerable_themes]
+        ParsedCli.themes_list || opts[:popular_themes] || opts[:all_themes] || opts[:vulnerable_themes]
       end
 
       def enum_themes
@@ -125,7 +152,7 @@ module WPScan
 
         themes.each(&:version)
 
-        themes.select!(&:vulnerable?) if ParsedCli.enumerate[:vulnerable_themes]
+        themes.select!(&:vulnerable?) if ParsedCli.enumerate&.dig(:vulnerable_themes)
 
         output('themes', themes: themes)
       end

--- a/spec/app/controllers/enumeration_spec.rb
+++ b/spec/app/controllers/enumeration_spec.rb
@@ -212,5 +212,51 @@ describe WPScan::Controller::Enumeration do
         end
       end
     end
+
+    context 'when --plugins-list is supplied without --enumerate' do
+      let(:cli_args) { "#{super()} --plugins-list a,b,c" }
+
+      it 'calls #enum_plugins' do
+        expect(controller).to receive(:enum_plugins)
+        expect(controller.formatter).not_to receive(:output).with('@notice', anything, anything)
+        controller.run
+      end
+    end
+
+    context 'when --themes-list is supplied without --enumerate' do
+      let(:cli_args) { "#{super()} --themes-list a,b,c" }
+
+      it 'calls #enum_themes' do
+        expect(controller).to receive(:enum_themes)
+        expect(controller.formatter).not_to receive(:output).with('@notice', anything, anything)
+        controller.run
+      end
+    end
+
+    %w[vp ap p].each do |choice|
+      context "when --plugins-list collides with --enumerate #{choice}" do
+        let(:cli_args) { "#{super()} -e #{choice} --plugins-list a,b,c" }
+
+        it 'emits a notice and still calls #enum_plugins' do
+          expect(controller.formatter).to receive(:output)
+            .with('@notice', hash_including(:msg), 'enumeration')
+          expect(controller).to receive(:enum_plugins)
+          controller.run
+        end
+      end
+    end
+
+    %w[vt at t].each do |choice|
+      context "when --themes-list collides with --enumerate #{choice}" do
+        let(:cli_args) { "#{super()} -e #{choice} --themes-list a,b,c" }
+
+        it 'emits a notice and still calls #enum_themes' do
+          expect(controller.formatter).to receive(:output)
+            .with('@notice', hash_including(:msg), 'enumeration')
+          expect(controller).to receive(:enum_themes)
+          controller.run
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Proposed changes

  * Make `--plugins-list` and `--themes-list` first-class triggers for plugin/theme enumeration: passing either option now runs the corresponding enumeration even without a matching `--enumerate` choice.
  * When `--plugins-list` is combined with a colliding `--enumerate` choice (`vp`/`ap`/`p`) - or `--themes-list` with `vt`/`at`/`t` - the list option takes precedence, the colliding enumerate keys are stripped, and a `@notice` is emitted naming the ignored choice(s).
  * Updated the `-e/--enumerate` help text to document the override behaviour.
  * Added nil-safety in `enum_message` and the `vulnerable?` post-filters in `enum_plugins`/`enum_themes` so the new list-only code paths don't dereference a nil `ParsedCli.enumerate`.

  ## Why are these changes being made?

  * Previously, `--plugins-list` / `--themes-list` only filtered within an already-enabled enumeration. After the recent removal of default enumerations (#2008), running e.g. `wpscan --url … --plugins-list mylist.txt` silently did nothing, which is counter-intuitive.
  * When users combined both options (e.g. `--enumerate ap --plugins-list mylist.txt`), the enumerate choice was silently dropped from the list source but still affected the on-screen wording and (for `vp`) the vulnerable-only post-filter; so behaviour drifted from what the user asked for, with no indication.
  * Making the list options take precedence and warning on collision matches user expectation: "if I gave you an explicit list, use that list."

  ## Testing instructions


  * Manual sanity checks:
    * `wpscan --url <site> --plugins-list woocommerce --detection-mode mixed` → plugin enumeration runs, no notice, no crash.
    * `wpscan --url <site> --enumerate ap --plugins-list woocommerce` → notice printed (`--plugins-list provided; ignoring colliding --enumerate choice(s): all_plugins`), provided list is used, "All Plugins"
  wording suppressed.
    * `wpscan --url <site> --enumerate vp --plugins-list woocommerce --api-token <token>` → notice printed, list used, no vulnerable-only post-filter applied.
    * `wpscan --url <site> --themes-list twentytwentyfour` → theme enumeration runs without `--enumerate`.
    * `wpscan --help` → `-e/--enumerate` shows the new note about list options overriding vp/ap/p and vt/at/t.
    * `wpscan --url <site> --enumerate vp` (no list) → unchanged behaviour.