### PR TITLE
Added support for --format jsonl (newline delimited JSON which is emitted as soon as things are found).

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -5,6 +5,7 @@ require_relative 'formatters/cli'
 require_relative 'formatters/cli_no_colour'
 require_relative 'formatters/cli_no_color'
 require_relative 'formatters/json'
+require_relative 'formatters/jsonl'
 require_relative 'formatters/sarif'
 
 # Base controllers

--- a/app/formatters/jsonl.rb
+++ b/app/formatters/jsonl.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module WPScan
+  module Formatter
+    # JSON Lines formatter — streams one self-contained JSON object per
+    # template render as the scan progresses. Reuses every app/views/json/*.erb
+    # template via base_format, so output content matches `-f json` but is
+    # emitted incrementally and can be piped directly into tools like `jq`.
+    class Jsonl < Base
+      def base_format
+        'json'
+      end
+
+      def output(tpl, vars = {}, controller_name = nil)
+        rendered = render(tpl, vars, controller_name)
+                   .encode('UTF-8', invalid: :replace, undef: :replace)
+        fragment = rendered.strip.chomp(',')
+        return if fragment.empty?
+
+        $stdout.puts JSON.generate(JSON.parse("{#{fragment}}"))
+        $stdout.flush
+      end
+    end
+  end
+end

--- a/spec/app/formatters/jsonl_spec.rb
+++ b/spec/app/formatters/jsonl_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+describe WPScan::Formatter::Jsonl do
+  subject(:formatter) { described_class.new }
+
+  before { formatter.views_directories << FIXTURES_VIEWS }
+
+  its(:format)            { should eq 'jsonl' }
+  its(:base_format)       { should eq 'json' }
+  its(:user_interaction?) { should be false }
+
+  describe '#beautify' do
+    it 'is a no-op (lines are already final)' do
+      expect { formatter.beautify }.not_to output.to_stdout
+    end
+  end
+
+  describe '#output' do
+    it 'writes one JSON object per render, immediately, per call' do
+      expect do
+        2.times { formatter.output('@render_me', test: 'Working') }
+      end.to output("{\"test\":\"Working\"}\n" * 2).to_stdout
+    end
+
+    it 'keeps all keys from a single render together on one line' do
+      expect do
+        formatter.output('@render_me', test: 'a', var: 'b')
+      end.to output("{\"test\":\"a\",\"var\":\"b\"}\n").to_stdout
+    end
+
+    it 'skips empty renders' do
+      empty_tpl = FIXTURES_VIEWS.join('json', 'empty.erb')
+      File.write(empty_tpl, '')
+      begin
+        expect { formatter.output('@empty') }.not_to output.to_stdout
+      ensure
+        File.delete(empty_tpl)
+      end
+    end
+
+    context 'when invalid UTF-8 chars' do
+      it 'tries to convert/replace them' do
+        replacement = '�'
+        expected = "{\"test\":\"#{replacement}it#{replacement}s\"}\n"
+
+        expect do
+          formatter.output('@render_me', test: "\x93it\x92s".dup.force_encoding('CP1252'))
+        end.to output(expected).to_stdout
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #1828

  ## Proposed changes

  * Add new `--format jsonl` (JSON Lines) output option.
  * New `WPScan::Formatter::Jsonl` class in `app/formatters/jsonl.rb` that streams one self-contained JSON object per template render to `$stdout` as the scan progresses, instead of buffering and pretty-printing a single document at the end (as `--format json` does).
  * Reuses every existing `app/views/json/**/*.erb` template via `base_format = 'json'`.

  ## Why are these changes being made?

  * `--format json` only prints anything once the entire scan has finished, which makes it impossible to consume wpscan output in real time (e.g. piping into `jq` or another downstream tool). For long scans you stare at a blank console until the very end.
  * JSONL ([jsonlines.org](https://jsonlines.org/)) is the standard streaming-friendly counterpart to JSON: each line is a self-contained, parseable JSON object, so consumers can react as soon as a finding lands.

  ## Testing instructions

* Run a scan and observe the json lines being printed while it is happening.
* Confirm you can pipe the output into other tools, for example by appending `| jq`
* Run a longer running scan (e.g. `-e vp`) and verify you can already see output while the scan is still running, which is the whole point of this.