### PR TITLE
Added fetching and display of active install count for detected plugins and themes.

### DIFF
--- a/app/models/plugin.rb
+++ b/app/models/plugin.rb
@@ -36,6 +36,12 @@ module WPScan
         @version
       end
 
+      # @return [ String ]
+      def wordpress_org_api_url
+        encoded_slug = Addressable::URI.encode_component(slug, Addressable::URI::CharacterClasses::UNRESERVED)
+        "https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request[slug]=#{encoded_slug}"
+      end
+
       # @return [ Array<String> ]
       def potential_readme_filenames
         @potential_readme_filenames ||= Array(DB::DynamicFinders::Plugin.df_data.dig(slug, 'Readme', 'path') || super)

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -42,6 +42,13 @@ module WPScan
         @version
       end
 
+      # @return [ String ]
+      def wordpress_org_api_url
+        encoded_slug = Addressable::URI.encode_component(slug, Addressable::URI::CharacterClasses::UNRESERVED)
+        'https://api.wordpress.org/themes/info/1.2/?action=theme_information' \
+          "&request[slug]=#{encoded_slug}&request[fields][active_installs]=1"
+      end
+
       # @return [ Theme ]
       def parent_theme
         return unless template

--- a/app/models/wp_item.rb
+++ b/app/models/wp_item.rb
@@ -76,6 +76,40 @@ module WPScan
         @last_updated ||= metadata['last_updated']
       end
 
+      # Number of active installs as reported by the wordpress.org API.
+      # See https://codex.wordpress.org/WordPress.org_API
+      #
+      # @return [ Integer, nil ] nil if the item is not on wordpress.org or the lookup fails
+      def active_installs
+        return @active_installs if defined?(@active_installs)
+
+        @active_installs = fetch_active_installs
+      end
+
+      # @return [ String, nil ] The wordpress.org API URL returning info for this item.
+      #   Subclasses override this; nil disables the lookup.
+      def wordpress_org_api_url
+        nil
+      end
+
+      # Timeout (in seconds) for the wordpress.org API lookup. Kept low so a slow
+      # or unreachable wordpress.org does not noticeably stall the scan.
+      WORDPRESS_ORG_API_TIMEOUT = 5
+
+      # @return [ Integer, nil ]
+      def fetch_active_installs
+        url = wordpress_org_api_url
+        return nil unless url
+
+        res = Browser.get(url, connecttimeout: WORDPRESS_ORG_API_TIMEOUT, timeout: WORDPRESS_ORG_API_TIMEOUT)
+        return nil unless res.code == 200
+
+        data = JSON.parse(res.body)
+        data.is_a?(Hash) ? data['active_installs'] : nil
+      rescue StandardError
+        nil
+      end
+
       # @return [ Boolean ]
       def outdated?
         @outdated ||= if version && latest_version

--- a/app/views/cli/wp_item.erb
+++ b/app/views/cli/wp_item.erb
@@ -5,6 +5,9 @@
 <% if @wp_item.last_updated -%>
  | Last Updated: <%= @wp_item.last_updated %>
 <% end -%>
+<% if @wp_item.active_installs -%>
+ | Active Installs: <%= ActiveSupport::NumberHelper.number_to_delimited(@wp_item.active_installs) %>
+<% end -%>
 <% if @wp_item.readme_url -%>
  | Readme: <%= @wp_item.readme_url %>
 <% end -%>

--- a/app/views/json/wp_item.erb
+++ b/app/views/json/wp_item.erb
@@ -2,6 +2,7 @@
 "location": <%= @wp_item.url.to_json %>,
 "latest_version": <%= @wp_item.latest_version ? @wp_item.latest_version.number.to_json : nil.to_json %>,
 "last_updated": <%= @wp_item.last_updated.to_json %>,
+"active_installs": <%= @wp_item.active_installs.to_json %>,
 "outdated": <%= @wp_item.outdated?.to_json %>,
 "readme_url": <%= @wp_item.readme_url.to_json %>,
 "directory_listing": <%= @wp_item.directory_listing?.to_json %>,

--- a/spec/app/models/plugin_spec.rb
+++ b/spec/app/models/plugin_spec.rb
@@ -60,6 +60,12 @@ describe WPScan::Model::Plugin do
     end
   end
 
+  describe '#wordpress_org_api_url' do
+    its(:wordpress_org_api_url) do
+      should eql 'https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request[slug]=spec'
+    end
+  end
+
   describe 'potential_readme_filenames' do
     context 'when not set in the DF file' do
       its(:potential_readme_filenames) { should eql described_class::READMES }

--- a/spec/app/models/theme_spec.rb
+++ b/spec/app/models/theme_spec.rb
@@ -275,6 +275,15 @@ describe WPScan::Model::Theme do
     end
   end
 
+  describe '#wordpress_org_api_url' do
+    before { stub_request(:get, /.*\.css\z/).to_return(body: '') }
+
+    its(:wordpress_org_api_url) do
+      should eql 'https://api.wordpress.org/themes/info/1.2/?action=theme_information' \
+                 '&request[slug]=spec&request[fields][active_installs]=1'
+    end
+  end
+
   describe '#parent_theme' do
     before do
       stub_request(:get, blog.url('wp-content/themes/spec/style.css'))

--- a/spec/app/models/wp_item_spec.rb
+++ b/spec/app/models/wp_item_spec.rb
@@ -128,4 +128,56 @@ describe WPScan::Model::WpItem do
   describe '#head_and_get' do
     xit
   end
+
+  describe '#active_installs' do
+    context 'when wordpress_org_api_url is nil' do
+      it 'returns nil and does not make a request' do
+        expect(WPScan::Browser).not_to receive(:get)
+        expect(wp_item.active_installs).to be_nil
+      end
+    end
+
+    context 'when wordpress_org_api_url is set' do
+      let(:api_url) { 'https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request[slug]=test_item' }
+
+      before { allow(wp_item).to receive(:wordpress_org_api_url).and_return(api_url) }
+
+      context 'on a successful response' do
+        before { stub_request(:get, api_url).to_return(status: 200, body: { 'active_installs' => 1234 }.to_json) }
+
+        it 'returns the active_installs value' do
+          expect(wp_item.active_installs).to eql 1234
+        end
+
+        it 'memoizes the result' do
+          expect(WPScan::Browser).to receive(:get).once.and_call_original
+          2.times { wp_item.active_installs }
+        end
+      end
+
+      context 'on a non-200 response' do
+        before { stub_request(:get, api_url).to_return(status: 404, body: '') }
+
+        it 'returns nil' do
+          expect(wp_item.active_installs).to be_nil
+        end
+      end
+
+      context 'on invalid JSON' do
+        before { stub_request(:get, api_url).to_return(status: 200, body: 'not json') }
+
+        it 'returns nil' do
+          expect(wp_item.active_installs).to be_nil
+        end
+      end
+
+      context 'when active_installs key is absent' do
+        before { stub_request(:get, api_url).to_return(status: 200, body: '{}') }
+
+        it 'returns nil' do
+          expect(wp_item.active_installs).to be_nil
+        end
+      end
+    end
+  end
 end

--- a/spec/output/main_theme/no_verbose.json
+++ b/spec/output/main_theme/no_verbose.json
@@ -4,6 +4,7 @@
     "location": "http://ex.lo/wp-content/themes/test/",
     "latest_version": null,
     "last_updated": null,
+    "active_installs": null,
     "outdated": false,
     "readme_url": "http://ex.lo/wp-content/themes/test/readme.txt",
     "directory_listing": false,

--- a/spec/output/main_theme/verbose.json
+++ b/spec/output/main_theme/verbose.json
@@ -4,6 +4,7 @@
     "location": "http://ex.lo/wp-content/themes/test/",
     "latest_version": null,
     "last_updated": null,
+    "active_installs": null,
     "outdated": false,
     "readme_url": "http://ex.lo/wp-content/themes/test/readme.txt",
     "directory_listing": false,

--- a/spec/output/main_theme/vulnerable.json
+++ b/spec/output/main_theme/vulnerable.json
@@ -4,6 +4,7 @@
     "location": "http://ex.lo/wp-content/themes/dignitas-themes/",
     "latest_version": null,
     "last_updated": null,
+    "active_installs": null,
     "outdated": false,
     "readme_url": "http://ex.lo/wp-content/themes/dignitas-themes/readme.txt",
     "directory_listing": false,


### PR DESCRIPTION
Resolves https://github.com/wpscanteam/wpscan/issues/1866

## Proposed changes

  * Add an `active_installs` lookup for identified plugins and themes via the wordpress.org info API (see [WordPress.org_API codex](https://codex.wordpress.org/WordPress.org_API)).
  * Plugins use `https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request[slug]=<slug>`; themes use
  `https://api.wordpress.org/themes/info/1.2/?action=theme_information&request[slug]=<slug>&request[fields][active_installs]=1` (themes only return the field when explicitly requested).
  * Render the count in CLI output formatted with thousands separators (e.g. `1,000,000`), and emit it as a raw integer in JSON output under the `active_installs` key.
  * Memoize the result per item so the API is hit at most once per plugin/theme.

  ## Why are these changes being made?

  * Resolves [#1866](https://github.com/wpscanteam/wpscan/issues/1866). When assessing a site, the number of active installs is a useful signal: plugins/themes with low install counts are good candidates for closer review since they tend to have had fewer eyes on them. Today users have to feed the slug list into a separate script; surfacing the count directly in WPScan output removes that step.

  ## Testing instructions

* Run a scan and verify the active installs count shows up for a detected plugin/theme as long as it is a w.org one.
