### PR TITLE
Add missing notice view for JSON/JSONL formatters

### DIFF
--- a/app/views/json/notice.erb
+++ b/app/views/json/notice.erb
@@ -1,0 +1,1 @@
+"notice": <%= @msg.to_json %>,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Related to #2011

## Proposed changes

* Add the missing `app/views/json/notice.erb` template that is required for JSON/JSONL formatters to display notice messages.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When using JSON or JSONL output formats (`-f json` or `-f jsonl`), WPScan would crash with a `RuntimeError: View not found for json/notice` error when trying to display notice messages, particularly enumeration option collision warnings (e.g., when `--plugins-list` conflicts with `--enumerate vp`) introduced in https://github.com/wpscanteam/wpscan/pull/2011

The CLI formatter already has a notice view (`app/views/cli/notice.erb`), but the JSON formatter was missing its equivalent template. Since the JSONL formatter reuses JSON templates, this fix resolves the issue for both formats.

While most notices in WPScan are guarded by `user_interaction?` (making them CLI-only), the enumeration collision warning is intentionally not guarded. This is because:
- It informs about modified scan behavior (ignored options) that affects results
- Programmatic consumers parsing JSON/JSONL output should be aware their requested options were modified
- It's purely informational, not interactive (unlike database update prompts)

Therefore, we're adding the missing notice view rather than making this notice CLI-only, maintaining the ability for JSON/JSONL consumers to receive important scan behavior notifications.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test that notice messages work correctly in JSON/JSONL formats and no errors are thrown:

```
bundle exec ruby -Ilib bin/wpscan --url https://example.com --enumerate vp --plugins-list /tmp/test-list.txt -f json
bundle exec ruby -Ilib bin/wpscan --url https://example.com --enumerate vp --plugins-list /tmp/test-list.txt -f jsonl
```

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor grants Automattic Inc. the unlimited, non-exclusive right to reuse, modify, and relicense the code.

