### PR TITLE
Update AGENTS.md to emphasize running rubocop after code changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,14 @@ WPScan is a WordPress security scanner written in Ruby. It provides WordPress-sp
 - Scanner framework lives in `lib/wpscan/` (Target, Browser, Controller::Base, Scan, Finders, Formatter, etc.) alongside the WordPress-specific code
 - Supports WordPress-specific security scanning features
 
+## Development Best Practices
+
+### Code Style
+- **Always run rubocop after making changes** to ensure code style compliance
+- Run `bundle exec rubocop -a` to auto-fix issues
+- For specific files: `bundle exec rubocop -a file1.rb file2.rb`
+- The project uses RuboCop for Ruby style enforcement
+
 ## Development Commands
 
 ### Setup
@@ -42,6 +50,10 @@ bundle exec rubocop
 
 # Auto-fix rubocop issues
 bundle exec rubocop -a
+
+# IMPORTANT: Always run rubocop after making code changes
+# Run on specific files being modified:
+bundle exec rubocop -a path/to/file1.rb path/to/file2.rb
 ```
 
 ### Building


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Related to #

## Proposed changes

* Update AGENTS.md to emphasize running rubocop after code changes

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

:)

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

n/a

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor grants Automattic Inc. the unlimited, non-exclusive right to reuse, modify, and relicense the code.

