### PR TITLE
Add excluded vulnerabilities to JSON output

### DIFF
--- a/app/views/json/core/started.erb
+++ b/app/views/json/core/started.erb
@@ -5,3 +5,6 @@
 "target_url": <%= @url.to_s.to_json %>,
 "target_ip": <%= @ip.to_s.to_json %>,
 "effective_url": <%= @effective_url.to_s.to_json %>,
+<% if WPScan::ParsedCli.exclude_vulns && !WPScan::ParsedCli.exclude_vulns.empty? -%>
+"excluded_vulnerabilities": <%= Array(WPScan::ParsedCli.exclude_vulns).to_json %>,
+<% end -%>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Related to https://github.com/wpscanteam/wpscan/pull/2017

## Proposed changes

* Add `excluded_vulnerabilities` field to JSON output when `--exclude-vulns` is used
* Ensures JSON output has parity with CLI output for vulnerability exclusions

```
{
  (...)
  "effective_url": "https://kozmo.ragostini.com/",
  "excluded_vulnerabilities": [
    "df32569a-e4fe-430b-8310-df7be80d7249",
    "2b76b9a1-f7b2-4ee3-91bf-34c863c24dc9"
  ],
  (...)
}
```

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The recent UUID-based vulnerability exclusion feature (PR #2017) allows users to exclude specific vulnerabilities via `--exclude-vulns`. While the CLI output correctly displays these exclusions, the JSON output was missing this information entirely. This gap meant tools consuming JSON output couldn't determine if vulnerabilities were intentionally excluded, potentially leading to misinterpretation of scan results

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. **Test with excluded vulnerabilities:**

   ```bash
   bundle exec ruby -Ilib bin/wpscan --url https://example-wordpress-site.com --format json --exclude-vulns uuid-1,uuid-2
   ```

   **Expected output** (relevant portion):

   ```json
   {
     "start_time": 1234567890,
     "start_memory": 12345678,
     "command_line": "wpscan --url https://example-wordpress-site.com --format json --exclude-vulns uuid-1,uuid-2",
     "hostname": "scanner.local",
     "target_url": "https://example-wordpress-site.com/",
     "target_ip": "1.2.3.4",
     "effective_url": "https://example-wordpress-site.com/",
     "excluded_vulnerabilities": ["uuid-1", "uuid-2"],
     ...
   }
   ```

2. **Test without excluded vulnerabilities:**

   ```bash
   bundle exec ruby -Ilib bin/wpscan --url https://example-wordpress-site.com --format json
   ```

   **Expected:** The `excluded_vulnerabilities` field should NOT appear in the JSON output when no exclusions are specified.

3. **Verify JSON validity:**

   ```bash
   bundle exec ruby -Ilib bin/wpscan --url https://example-wordpress-site.com --format json --exclude-vulns test-uuid | python3 -m json.tool
   ```

   **Expected:** JSON should parse without errors.

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor grants Automattic Inc. the unlimited, non-exclusive right to reuse, modify, and relicense the code.

