### PR TITLE
Add status page link to API connection errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ cli_options:
 
 The API Token will be automatically loaded from the ENV variable `WPSCAN_API_TOKEN` if present. If the `--api-token` CLI option is also provided, the value from the CLI will be used.
 
+## API Service Status
+
+If you experience connection issues with the WPScan API, you can check the service status at https://status.wpscan.com/. When API connection errors occur, WPScan will include a link to the status page in the error message.
 
 ## Enumerating usernames
 

--- a/app/controllers/vuln_api.rb
+++ b/app/controllers/vuln_api.rb
@@ -30,7 +30,7 @@ module WPScan
 
         raise Error::InvalidApiToken if api_status['status'] == 'forbidden'
         raise Error::ApiLimitReached if api_status['requests_remaining'] == 0
-        raise api_status['http_error'] if api_status['http_error']
+        raise Error::ApiConnectionError, api_status['http_error'] if api_status['http_error']
       end
 
       def after_scan

--- a/lib/wpscan/errors/vuln_api.rb
+++ b/lib/wpscan/errors/vuln_api.rb
@@ -25,5 +25,20 @@ module WPScan
           'Provide it via --api-token TOKEN or the WPSCAN_API_TOKEN environment variable.'
       end
     end
+
+    # Error raised when there's a connection issue with the WPScan API
+    class ApiConnectionError < Standard
+      attr_reader :original_error
+
+      def initialize(original_error)
+        @original_error = original_error
+        super()
+      end
+
+      def to_s
+        "Unable to connect to the WPScan API: #{original_error}. " \
+          'Please check https://status.wpscan.com/ for service status.'
+      end
+    end
   end
 end

--- a/spec/app/controllers/vuln_api_spec.rb
+++ b/spec/app/controllers/vuln_api_spec.rb
@@ -61,7 +61,11 @@ describe WPScan::Controller::VulnApi do
 
           it 'raises an API connection error' do
             expect { controller.before_scan }
-              .to raise_error(WPScan::Error::ApiConnectionError, 'Unable to connect to the WPScan API: HTTP Error: mock-url (Timeout was reached). Please check https://status.wpscan.com/ for service status.')
+              .to raise_error(
+                WPScan::Error::ApiConnectionError,
+                'Unable to connect to the WPScan API: HTTP Error: mock-url (Timeout was reached). ' \
+                'Please check https://status.wpscan.com/ for service status.'
+              )
           end
         end
 

--- a/spec/app/controllers/vuln_api_spec.rb
+++ b/spec/app/controllers/vuln_api_spec.rb
@@ -59,9 +59,9 @@ describe WPScan::Controller::VulnApi do
               )
           end
 
-          it 'raises an HTTP error' do
+          it 'raises an API connection error' do
             expect { controller.before_scan }
-              .to raise_error(WPScan::Error::HTTP, 'HTTP Error: mock-url (Timeout was reached)')
+              .to raise_error(WPScan::Error::ApiConnectionError, 'Unable to connect to the WPScan API: HTTP Error: mock-url (Timeout was reached). Please check https://status.wpscan.com/ for service status.')
           end
         end
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Fixes #1567

## Proposed changes

* Add new `ApiConnectionError` class that includes the WPScan status page URL
* Update VulnApi controller to use the new error class for connection failures
* Add API Service Status section to README documentation

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When users encounter API connection errors, they currently have no way to know if the issue is due to a service outage or their local configuration. Adding a link to https://status.wpscan.com/ in error messages helps users quickly check if there's a known service issue, reducing confusion and support requests. The status page provides real-time information about API availability and any ongoing incidents.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. **Test with invalid API token to trigger connection error:**

   ```bash
   bundle exec ruby -Ilib bin/wpscan --url https://example.com --api-token invalid_token
   ```

   **Expected error message must include:**

   ```
   (...) Please check https://status.wpscan.com/ for service status.
   ```

2. **Simulate network timeout (can use firewall rules or network tools):**

   - Block access to wpscan.com temporarily
   - Run WPScan with a valid API token
   - Should see error message with status page link
 
