### PR TITLE
Limited maximum redirects in a couple more places, just to be safe.

### DIFF
--- a/app/finders/users/author_id_brute_forcing.rb
+++ b/app/finders/users/author_id_brute_forcing.rb
@@ -55,7 +55,7 @@ module WPScan
         end
 
         def full_request_params
-          { followlocation: true }
+          { followlocation: true, maxredirs: 10 }
         end
 
         # @param [ Typhoeus::Response ] res

--- a/lib/wpscan/target/hashes.rb
+++ b/lib/wpscan/target/hashes.rb
@@ -9,7 +9,7 @@ module WPScan
     #
     # @return [ String ] The md5sum of the page
     def self.page_hash(page)
-      page = WPScan::Browser.get(page, followlocation: true) unless page.is_a?(Typhoeus::Response)
+      page = WPScan::Browser.get(page, followlocation: true, maxredirs: 10) unless page.is_a?(Typhoeus::Response)
 
       # Removes comments and script tags before computing the hash
       # to remove any potential cached stuff


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Related to https://github.com/wpscanteam/wpscan/issues/1204

## Proposed changes

* Limit redirections to a maximum of 10 in more places.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Investigating #1204 I found that there are these places where we don't limit the redirects. cURL very likely catches recursive stuff at some point, but this way we are even safer.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Trust CI? 🙂 

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor grants Automattic Inc. the unlimited, non-exclusive right to reuse, modify, and relicense the code.

