### PR TITLE
Added more cases (and checking for them) to the acceptance tests.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,113 +57,13 @@ jobs:
       run: |
         mkdir wordpress-test
         cd wordpress-test
+        bash "${GITHUB_WORKSPACE}/spec/integration/setup_wp_test_env.sh"
 
-        # Configure and start DDEV
-        ddev config --project-type=wordpress --php-version=8.1 --docroot=wordpress
-        ddev start
-
-        # Install WordPress
-        ddev exec wp core download --path=wordpress
-        ddev exec wp core install \
-          --path=wordpress \
-          --url=https://wordpress-test.ddev.site \
-          --title="WPScan Integration Test" \
-          --admin_user=admin \
-          --admin_password=password \
-          --admin_email=test@example.com \
-          --skip-email
-
-        # Install vulnerable plugins and theme for testing
-        ddev exec wp plugin install contact-form-7 --version=5.3.2 --activate --path=wordpress 2>/dev/null
-        ddev exec wp plugin install woocommerce --version=4.6.1 --activate --path=wordpress 2>/dev/null
-        ddev exec wp plugin install wordpress-seo --version=15.5 --activate --path=wordpress 2>/dev/null
-        ddev exec wp theme install twentynineteen --version=1.8 --activate --path=wordpress 2>/dev/null
-
-        # Create additional non-admin users so WPScan's user enumeration has more than just `admin` to find
-        ddev exec wp user create editor1 editor1@example.com --role=editor --user_pass='editor-pass-123' --path=wordpress
-        ddev exec wp user create author1 author1@example.com --role=author --user_pass='author-pass-123' --path=wordpress
-
-        # Enable user registration so the Registration interesting-finding fires (wp-login.php?action=register)
-        ddev exec wp option update users_can_register 1 --path=wordpress
-
-        # Set permalink structure to "Plain" (?p=N) so media enumeration (-e m) can find attachments
-        # by iterating attachment IDs against the homepage. Per `wpscan --hh`: media detection requires plain permalinks.
-        ddev exec wp option update permalink_structure '' --path=wordpress
-
-        # Upload a tiny PNG as a media attachment so the medias enumerator has something to find.
-        printf '\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82' > test-image.png
-        ddev exec wp media import test-image.png --path=wordpress
-
-        # Drop files / dirs that trigger WPScan's "interesting findings" / config-backup / db-export /
-        # timthumb / upload-sql-dump / backup-db / mu-plugins / fantastico / search-replace-db /
-        # duplicator-installer / emergency-pwd-reset finders.
-        # Each path matches what the corresponding finder under app/finders/interesting_findings/ probes.
-        # See issue #807: the test site should demo as many detection paths as is reasonable.
-        # Content matters: each finder validates the response body, not just the path. Patterns used below
-        # mirror what the corresponding finder in app/finders/ expects (e.g. ConfigBackups requires
-        # /define/i + no <html, DbExports/UploadSQLDump require SQL DDL keywords, Timthumbs requires
-        # HTTP 400 + "no image specified", FantasticoFileslist requires a non-empty text/plain body).
-        echo "<?php define('DB_NAME','wordpress'); define('DB_USER','root');" > wordpress/wp-config.bak
-        echo 'CREATE TABLE foo (id INT); INSERT INTO foo VALUES (1);' > wordpress/backup.sql
-        echo 'PHP Notice: simulated debug entry' > wordpress/wp-content/debug.log
-        # Real timthumb.php returns HTTP 400 + "no image specified" when called without query args
-        echo '<?php http_response_code(400); echo "no image specified";' > wordpress/timthumb.php
-        echo 'duplicator installer log' > wordpress/installer-log.txt
-        echo '<?php echo "emergency password reset script";' > wordpress/emergency.php
-        echo '<?php exit; /* search replace db */' > wordpress/searchreplacedb2.php
-        echo 'fantastico fileslist' > wordpress/fantastico_fileslist.txt
-        mkdir -p wordpress/wp-content/uploads
-        echo 'CREATE TABLE bar (id INT); INSERT INTO bar VALUES (1);' > wordpress/wp-content/uploads/dump.sql
-        mkdir -p wordpress/wp-content/backup-db
-        echo 'backup-db dir' > wordpress/wp-content/backup-db/index.html
-        mkdir -p wordpress/wp-content/mu-plugins
-        echo '<?php /* mu-plugin */' > wordpress/wp-content/mu-plugins/test.php
-        echo 'mu-plugins dir' > wordpress/wp-content/mu-plugins/index.html
-
-        # Verify site returns HTTP 200 (will exit non-zero on 4xx/5xx errors)
-        curl -k -f -s -o /dev/null -w "✓ WordPress responding: HTTP %{http_code}\n" https://wordpress-test.ddev.site
-
-    - name: Update WPScan database
-      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
-      run: bundle exec ruby -Ilib bin/wpscan --update
-
-    - name: Run WPScan against test site
+    - name: Run WPScan against test site and verify results
       if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
       env:
         WPSCAN_API_TOKEN: ${{ secrets.WPSCAN_API_TOKEN }}
-      run: |
-        # Verify API token is configured
-        if [ -z "${WPSCAN_API_TOKEN}" ]; then
-          echo "Error: WPSCAN_API_TOKEN secret is not configured"
-          exit 1
-        fi
-
-        # Run WPScan with explicit enumeration (exit code 5 = vulnerabilities found, which we expect)
-        # Note: Using passive detection to avoid false positives in test environment
-        set +e
-        bundle exec ruby -Ilib bin/wpscan \
-          --url https://wordpress-test.ddev.site \
-          --disable-tls-checks \
-          --format json \
-          --output scan-results.json \
-          --api-token "${WPSCAN_API_TOKEN}" \
-          -e vp,vt,u,cb,dbe,tt,m1-5 \
-          --plugins-detection passive \
-          --themes-detection passive
-        EXIT_CODE=$?
-        set -e
-
-        # Verify we found vulnerabilities (exit code 5)
-        if [ "${EXIT_CODE}" -ne 5 ]; then
-          echo "✗ Expected exit code 5 (vulnerabilities found), got ${EXIT_CODE}"
-          exit 1
-        fi
-
-        echo "✓ WPScan found vulnerabilities (exit code 5)"
-
-    - name: Verify scan results
-      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
-      run: bundle exec ruby spec/integration/verify_results.rb scan-results.json
+      run: bash spec/integration/run_scan.sh
 
     - name: Upload scan results
       if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,18 @@ jobs:
         ddev exec wp plugin install wordpress-seo --version=15.5 --activate --path=wordpress 2>/dev/null
         ddev exec wp theme install twentynineteen --version=1.8 --activate --path=wordpress 2>/dev/null
 
+        # Create additional non-admin users so WPScan's user enumeration has more than just `admin` to find
+        ddev exec wp user create editor1 editor1@example.com --role=editor --user_pass='editor-pass-123' --path=wordpress
+        ddev exec wp user create author1 author1@example.com --role=author --user_pass='author-pass-123' --path=wordpress
+
+        # Drop files that trigger WPScan's "interesting findings" / config-backup / db-export / timthumb finders.
+        # See issue #807: the test site should demo as many detection paths as is reasonable.
+        echo '<?php /* leaked wp-config backup */' > wordpress/wp-config.bak
+        echo '-- mysql dump' > wordpress/backup.sql
+        echo 'PHP Notice: simulated debug entry' > wordpress/wp-content/debug.log
+        # timthumb.php at the docroot — first probed location in db/timthumbs-v3.txt
+        echo '<?php /* timthumb */' > wordpress/timthumb.php
+
         # Verify site returns HTTP 200 (will exit non-zero on 4xx/5xx errors)
         curl -k -f -s -o /dev/null -w "✓ WordPress responding: HTTP %{http_code}\n" https://wordpress-test.ddev.site
 
@@ -106,7 +118,7 @@ jobs:
           --format json \
           --output scan-results.json \
           --api-token "${WPSCAN_API_TOKEN}" \
-          -e vp,vt \
+          -e vp,vt,u,cb,dbe,tt \
           --plugins-detection passive \
           --themes-detection passive
         EXIT_CODE=$?

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,13 +83,42 @@ jobs:
         ddev exec wp user create editor1 editor1@example.com --role=editor --user_pass='editor-pass-123' --path=wordpress
         ddev exec wp user create author1 author1@example.com --role=author --user_pass='author-pass-123' --path=wordpress
 
-        # Drop files that trigger WPScan's "interesting findings" / config-backup / db-export / timthumb finders.
+        # Enable user registration so the Registration interesting-finding fires (wp-login.php?action=register)
+        ddev exec wp option update users_can_register 1 --path=wordpress
+
+        # Set permalink structure to "Plain" (?p=N) so media enumeration (-e m) can find attachments
+        # by iterating attachment IDs against the homepage. Per `wpscan --hh`: media detection requires plain permalinks.
+        ddev exec wp option update permalink_structure '' --path=wordpress
+
+        # Upload a tiny PNG as a media attachment so the medias enumerator has something to find.
+        printf '\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82' > test-image.png
+        ddev exec wp media import test-image.png --path=wordpress
+
+        # Drop files / dirs that trigger WPScan's "interesting findings" / config-backup / db-export /
+        # timthumb / upload-sql-dump / backup-db / mu-plugins / fantastico / search-replace-db /
+        # duplicator-installer / emergency-pwd-reset finders.
+        # Each path matches what the corresponding finder under app/finders/interesting_findings/ probes.
         # See issue #807: the test site should demo as many detection paths as is reasonable.
-        echo '<?php /* leaked wp-config backup */' > wordpress/wp-config.bak
-        echo '-- mysql dump' > wordpress/backup.sql
+        # Content matters: each finder validates the response body, not just the path. Patterns used below
+        # mirror what the corresponding finder in app/finders/ expects (e.g. ConfigBackups requires
+        # /define/i + no <html, DbExports/UploadSQLDump require SQL DDL keywords, Timthumbs requires
+        # HTTP 400 + "no image specified", FantasticoFileslist requires a non-empty text/plain body).
+        echo "<?php define('DB_NAME','wordpress'); define('DB_USER','root');" > wordpress/wp-config.bak
+        echo 'CREATE TABLE foo (id INT); INSERT INTO foo VALUES (1);' > wordpress/backup.sql
         echo 'PHP Notice: simulated debug entry' > wordpress/wp-content/debug.log
-        # timthumb.php at the docroot — first probed location in db/timthumbs-v3.txt
-        echo '<?php /* timthumb */' > wordpress/timthumb.php
+        # Real timthumb.php returns HTTP 400 + "no image specified" when called without query args
+        echo '<?php http_response_code(400); echo "no image specified";' > wordpress/timthumb.php
+        echo 'duplicator installer log' > wordpress/installer-log.txt
+        echo '<?php echo "emergency password reset script";' > wordpress/emergency.php
+        echo '<?php exit; /* search replace db */' > wordpress/searchreplacedb2.php
+        echo 'fantastico fileslist' > wordpress/fantastico_fileslist.txt
+        mkdir -p wordpress/wp-content/uploads
+        echo 'CREATE TABLE bar (id INT); INSERT INTO bar VALUES (1);' > wordpress/wp-content/uploads/dump.sql
+        mkdir -p wordpress/wp-content/backup-db
+        echo 'backup-db dir' > wordpress/wp-content/backup-db/index.html
+        mkdir -p wordpress/wp-content/mu-plugins
+        echo '<?php /* mu-plugin */' > wordpress/wp-content/mu-plugins/test.php
+        echo 'mu-plugins dir' > wordpress/wp-content/mu-plugins/index.html
 
         # Verify site returns HTTP 200 (will exit non-zero on 4xx/5xx errors)
         curl -k -f -s -o /dev/null -w "✓ WordPress responding: HTTP %{http_code}\n" https://wordpress-test.ddev.site
@@ -118,7 +147,7 @@ jobs:
           --format json \
           --output scan-results.json \
           --api-token "${WPSCAN_API_TOKEN}" \
-          -e vp,vt,u,cb,dbe,tt \
+          -e vp,vt,u,cb,dbe,tt,m1-5 \
           --plugins-detection passive \
           --themes-detection passive
         EXIT_CODE=$?

--- a/spec/integration/run_scan.sh
+++ b/spec/integration/run_scan.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Runs WPScan against the demo WordPress site set up by setup_wp_test_env.sh and
+# verifies the scan results via verify_results.rb. Used by the GitHub Actions
+# integration test (.github/workflows/build.yml) and runnable locally to iterate
+# on the integration test suite.
+#
+# Usage (local), after setup_wp_test_env.sh has prepared the site:
+#   export WPSCAN_API_TOKEN=...
+#   bash spec/integration/run_scan.sh
+#
+# Run from the wpscan repo root. The scan output is written to ./scan-results.json
+# in the current working directory.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TARGET_URL="${TARGET_URL:-https://wordpress-test.ddev.site}"
+OUTPUT_FILE="${OUTPUT_FILE:-scan-results.json}"
+
+if [ -z "${WPSCAN_API_TOKEN:-}" ]; then
+  echo "Error: WPSCAN_API_TOKEN is not set. Get a token at https://wpscan.com/profile"
+  exit 1
+fi
+
+# Update the local vulnerability DB so the scan has fresh data
+bundle exec ruby -I"${REPO_ROOT}/lib" "${REPO_ROOT}/bin/wpscan" --update
+
+# Run the scan. Exit code 5 means vulnerabilities were found, which is what we
+# expect for this intentionally-vulnerable demo site. Any other code is a failure.
+# Using passive plugin/theme detection to avoid false positives in the test env.
+set +e
+bundle exec ruby -I"${REPO_ROOT}/lib" "${REPO_ROOT}/bin/wpscan" \
+  --url "${TARGET_URL}" \
+  --disable-tls-checks \
+  --clear-cache \
+  --format json \
+  --output "${OUTPUT_FILE}" \
+  --api-token "${WPSCAN_API_TOKEN}" \
+  -e vp,vt,u,cb,dbe,tt \
+  --plugins-detection passive \
+  --themes-detection passive
+EXIT_CODE=$?
+set -e
+
+if [ "${EXIT_CODE}" -ne 5 ]; then
+  echo "Expected wpscan exit code 5 (vulnerabilities found), got ${EXIT_CODE}"
+  exit 1
+fi
+
+echo "WPScan found vulnerabilities (exit code 5)"
+
+# Verify the JSON output matches our expectations
+bundle exec ruby "${SCRIPT_DIR}/verify_results.rb" "${OUTPUT_FILE}"

--- a/spec/integration/setup_wp_test_env.sh
+++ b/spec/integration/setup_wp_test_env.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Sets up a local WordPress install via DDEV that exercises as many of WPScan's
+# detection paths as is reasonable. Used by the GitHub Actions integration test
+# (.github/workflows/build.yml) and runnable locally to spin up a "demo site"
+# for manual WPScan exploration — see https://github.com/wpscanteam/wpscan/issues/807.
+#
+# Usage (local):
+#   mkdir wordpress-test && cd wordpress-test
+#   bash /path/to/wpscan/spec/integration/setup_wp_test_env.sh
+#   # then point wpscan at https://wordpress-test.ddev.site
+#
+# Prerequisites: ddev, wp-cli (provided inside the ddev container), and a working
+# Docker runtime. The script must be run from an empty directory that will become
+# the DDEV project root.
+
+set -euo pipefail
+
+# Configure and start DDEV
+ddev config --project-type=wordpress --php-version=8.1 --docroot=wordpress
+
+# Disable PHP's display_errors. The pinned-vulnerable plugin versions (notably WooCommerce
+# 4.6.1) trigger deprecation warnings on PHP 8.1; when display_errors is on, those warnings
+# print to output BEFORE wp-signup.php's wp_redirect() runs, which corrupts the redirect.
+# That in turn makes the Multisite finder false-fire and the Registration finder look at the
+# wrong URL. Turning display_errors off keeps the responses clean and the finders happy.
+mkdir -p .ddev/php
+cat > .ddev/php/no-display-errors.ini <<'EOF'
+[PHP]
+display_errors = Off
+EOF
+
+ddev start
+
+# Install WordPress
+ddev exec wp core download --path=wordpress
+ddev exec wp core install \
+  --path=wordpress \
+  --url=https://wordpress-test.ddev.site \
+  --title="WPScan Integration Test" \
+  --admin_user=admin \
+  --admin_password=password \
+  --admin_email=test@example.com \
+  --skip-email
+
+# DDEV's WordPress project type defaults WP_DEBUG=1, which makes WordPress force
+# ini_set('display_errors', 1) at runtime — overriding our php.ini override and
+# letting old-plugin deprecation warnings (notably WooCommerce 4.6.1 on PHP 8.1)
+# spill into responses, breaking redirects (e.g. wp-signup.php → registration page).
+# Turn it off so the test environment behaves like a clean install.
+ddev exec wp config set WP_DEBUG false --raw --path=wordpress
+ddev exec wp config set WP_DEBUG_DISPLAY false --raw --path=wordpress
+
+# Create additional non-admin users so user enumeration has more than just `admin` to find
+ddev exec wp user create editor1 editor1@example.com --role=editor --user_pass='editor-pass-123' --path=wordpress
+ddev exec wp user create author1 author1@example.com --role=author --user_pass='author-pass-123' --path=wordpress
+
+# Install vulnerable plugins and theme LAST. Old plugin versions (especially WooCommerce 4.6.1)
+# emit deprecation warnings on modern PHP, which wp-cli then prints on every subsequent
+# WP-loading command. Doing this last keeps the rest of the setup output readable and fast.
+ddev exec wp plugin install contact-form-7 --version=5.3.2 --activate --path=wordpress 2>/dev/null
+ddev exec wp plugin install woocommerce --version=4.6.1 --activate --path=wordpress 2>/dev/null
+ddev exec wp plugin install wordpress-seo --version=15.5 --activate --path=wordpress 2>/dev/null
+ddev exec wp theme install twentynineteen --version=1.8 --activate --path=wordpress 2>/dev/null
+
+# Enable user registration AFTER plugin activation. Some plugins (notably WooCommerce) touch
+# user-registration settings during activation, so setting this last is the only way to ensure
+# users_can_register stays at 1 — required for the Registration interesting-finding to fire
+# (wp-login.php?action=register must render the #registerform).
+ddev exec wp option update users_can_register 1 --path=wordpress
+
+# Drop files / dirs that trigger WPScan's "interesting findings" / config-backup / db-export /
+# timthumb / upload-sql-dump / backup-db / mu-plugins / fantastico / search-replace-db /
+# duplicator-installer / emergency-pwd-reset finders. Each path matches what the corresponding
+# finder under app/finders/ probes.
+#
+# Content matters: each finder validates the response body, not just the path. Patterns used below
+# mirror what the corresponding finder expects (e.g. ConfigBackups requires /define/i + no <html,
+# DbExports/UploadSQLDump require SQL DDL keywords, Timthumbs requires HTTP 400 + "no image specified",
+# FantasticoFileslist requires a non-empty text/plain body).
+echo "<?php define('DB_NAME','wordpress'); define('DB_USER','root');" > wordpress/wp-config.bak
+echo 'CREATE TABLE foo (id INT); INSERT INTO foo VALUES (1);' > wordpress/backup.sql
+echo 'PHP Notice: simulated debug entry' > wordpress/wp-content/debug.log
+# Real timthumb.php returns HTTP 400 + "no image specified" when called without query args
+echo '<?php http_response_code(400); echo "no image specified";' > wordpress/timthumb.php
+# DuplicatorInstallerLog expects body to match /DUPLICATOR(-|\s)?(PRO|LITE)?:? INSTALL-LOG/i
+echo 'DUPLICATOR-LITE: INSTALL-LOG' > wordpress/installer-log.txt
+echo '<?php echo "emergency password reset script";' > wordpress/emergency.php
+# SearchReplaceDB2 expects body to match /by interconnect/i (signature of the real tool)
+echo '<?php echo "Search Replace DB by interconnect/it";' > wordpress/searchreplacedb2.php
+echo 'fantastico fileslist' > wordpress/fantastico_fileslist.txt
+mkdir -p wordpress/wp-content/uploads
+echo 'CREATE TABLE bar (id INT); INSERT INTO bar VALUES (1);' > wordpress/wp-content/uploads/dump.sql
+mkdir -p wordpress/wp-content/backup-db
+echo 'backup-db dir' > wordpress/wp-content/backup-db/index.html
+mkdir -p wordpress/wp-content/mu-plugins
+echo '<?php /* mu-plugin */' > wordpress/wp-content/mu-plugins/test.php
+echo 'mu-plugins dir' > wordpress/wp-content/mu-plugins/index.html
+
+# Verify site returns HTTP 200 (will exit non-zero on 4xx/5xx errors)
+curl -k -f -s -o /dev/null -w "WordPress responding: HTTP %{http_code}\n" https://wordpress-test.ddev.site

--- a/spec/integration/verify_results.rb
+++ b/spec/integration/verify_results.rb
@@ -171,6 +171,15 @@ puts '-' * 80
   end
 end
 
+# Media enumeration (requires plain permalinks; the test env sets permalink_structure='')
+medias = (results['medias'] || {}).keys
+if medias.any?
+  puts "✓ medias: found #{medias.length} attachment(s)"
+else
+  failures << 'medias: no attachments detected (expected at least one from wp media import)'
+  puts '✗ medias: no attachments detected'
+end
+
 puts
 
 # Verify interesting findings the test environment is set up to expose.
@@ -179,7 +188,19 @@ puts
 puts 'Interesting Findings:'
 puts '-' * 80
 
-EXPECTED_FINDING_TYPES = %w[debug_log readme wp_cron].freeze
+EXPECTED_FINDING_TYPES = %w[
+  debug_log
+  readme
+  wp_cron
+  registration
+  mu_plugins
+  backup_db
+  duplicator_installer_log
+  emergency_pwd_reset_script
+  search_replace_db2
+  fantastico_fileslist
+  upload_sql_dump
+].freeze
 finding_types = (results['interesting_findings'] || []).map { |f| f['type'] }
 
 EXPECTED_FINDING_TYPES.each do |type|

--- a/spec/integration/verify_results.rb
+++ b/spec/integration/verify_results.rb
@@ -134,6 +134,64 @@ else
 end
 
 puts
+
+# Verify user enumeration
+puts 'User Enumeration:'
+puts '-' * 80
+
+EXPECTED_USERS = %w[admin editor1 author1].freeze
+detected_users = (results['users'] || {}).keys
+
+EXPECTED_USERS.each do |username|
+  if detected_users.include?(username)
+    puts "✓ User detected: #{username}"
+  else
+    failures << "User '#{username}' not detected"
+    puts "✗ User: #{username} NOT DETECTED"
+  end
+end
+
+puts
+
+# Verify config backup, db export, and timthumb finders
+puts 'Config Backups / DB Exports / Timthumbs:'
+puts '-' * 80
+
+{
+  'config_backups' => 'wp-config.bak',
+  'db_exports' => 'backup.sql',
+  'timthumbs' => 'timthumb.php'
+}.each do |section, expected_filename|
+  entries = (results[section] || {}).keys
+  if entries.any? { |url| url.include?(expected_filename) }
+    puts "✓ #{section}: found entry matching '#{expected_filename}'"
+  else
+    failures << "#{section}: expected entry matching '#{expected_filename}', got #{entries.inspect}"
+    puts "✗ #{section}: no entry matching '#{expected_filename}' (found: #{entries.inspect})"
+  end
+end
+
+puts
+
+# Verify interesting findings the test environment is set up to expose.
+# Types are derived from the model class name via demodulize.underscore:
+# DebugLog -> debug_log, Readme -> readme, WPCron -> wp_cron.
+puts 'Interesting Findings:'
+puts '-' * 80
+
+EXPECTED_FINDING_TYPES = %w[debug_log readme wp_cron].freeze
+finding_types = (results['interesting_findings'] || []).map { |f| f['type'] }
+
+EXPECTED_FINDING_TYPES.each do |type|
+  if finding_types.include?(type)
+    puts "✓ Interesting finding: #{type}"
+  else
+    failures << "Interesting finding '#{type}' not reported"
+    puts "✗ Interesting finding: #{type} NOT REPORTED (got: #{finding_types.inspect})"
+  end
+end
+
+puts
 puts '=' * 80
 
 # Display summary

--- a/spec/integration/verify_results.rb
+++ b/spec/integration/verify_results.rb
@@ -171,15 +171,6 @@ puts '-' * 80
   end
 end
 
-# Media enumeration (requires plain permalinks; the test env sets permalink_structure='')
-medias = (results['medias'] || {}).keys
-if medias.any?
-  puts "✓ medias: found #{medias.length} attachment(s)"
-else
-  failures << 'medias: no attachments detected (expected at least one from wp media import)'
-  puts '✗ medias: no attachments detected'
-end
-
 puts
 
 # Verify interesting findings the test environment is set up to expose.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Resolves https://github.com/wpscanteam/wpscan/issues/807

## Proposed changes

* Add a bunch more things to detect to our acceptance tests.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To ensure that these things continue to work in the future.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* CI covers it, but due to the extracted scripts you can also run it locally now (if you really want to):

```
mkdir wordpress-test && cd wordpress-test
bash ../spec/integration/setup_wp_test_env.sh
cd ..
bash spec/integration/run_scan.sh
```

Note that this still does not cover EVERYTHING that WPScan can detect, but we'd need multiple environments setup to facilitate that, and with this PR I wanted to keep a balance between test runtime / complexity and coverage. We can always add more coverage as we go. 🙂 
