### PR TITLE
Add --wordlist-skip option to resume interrupted brute force attacks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,7 @@ Metrics/MethodLength:
   Exclude:
   - 'app/controllers/enumeration/cli_options.rb'
   - 'app/controllers/core/cli_options.rb'
+  - 'app/controllers/password_attack.rb'
 Metrics/ParameterLists:
   Max: 6
   MaxOptionalParameters: 4

--- a/app/controllers/password_attack.rb
+++ b/app/controllers/password_attack.rb
@@ -21,14 +21,18 @@ module WPScan
                          'Multicall will only work against WP < 4.4'],
                         choices: %w[wp-login xmlrpc xmlrpc-multicall],
                         normalize: %i[downcase underscore to_sym]),
-          OptString.new(['--login-uri URI', 'The URI of the login page if different from /wp-login.php'])
+          OptString.new(['--login-uri URI', 'The URI of the login page if different from /wp-login.php']),
+          OptInteger.new(['--wordlist-skip N',
+                          'Skip the first N passwords in the wordlist (resume from line N+1)'],
+                         default: 0)
         ]
       end
 
       def attack_opts
         @attack_opts ||= {
           show_progression: user_interaction?,
-          multicall_max_passwords: ParsedCli.multicall_max_passwords
+          multicall_max_passwords: ParsedCli.multicall_max_passwords,
+          wordlist_skip: ParsedCli.wordlist_skip
         }
       end
 

--- a/lib/wpscan/finders/finder/breadth_first_dictionary_attack.rb
+++ b/lib/wpscan/finders/finder/breadth_first_dictionary_attack.rb
@@ -9,6 +9,7 @@ module WPScan
         # @param [ String ] wordlist_path
         # @param [ Hash ] opts
         # @option opts [ Boolean ] :show_progression
+        # @option opts [ Integer ] :wordlist_skip Number of passwords to skip from the beginning
         #
         # @yield [ WPScan::User ] When a valid combination is found
         #
@@ -20,17 +21,34 @@ module WPScan
         # rubocop:disable all
         def attack(users, wordlist_path, opts = {})
           wordlist = File.open(wordlist_path)
+          skip_count = opts[:wordlist_skip] || 0
 
-          create_progress_bar(total: users.size * wordlist.count, show_progression: opts[:show_progression])
+          # Calculate total, accounting for skipped passwords
+          total_passwords = wordlist.count
+          effective_passwords = [total_passwords - skip_count, 0].max
+
+          create_progress_bar(total: users.size * effective_passwords, show_progression: opts[:show_progression])
 
           queue_count         = 0
           # Keep the number of requests sent for each users
           # to be able to correctly update the progress when a password is found
           user_requests_count = {}
+          current_line = 0
 
           users.each { |u| user_requests_count[u.username] = 0 }
 
+          # Show skip progress if skipping
+          if skip_count > 0 && opts[:show_progression]
+            progress_bar.log("[INFO] Skipping first #{skip_count} password(s) from wordlist...")
+          end
+
           File.foreach(wordlist, chomp: true) do |password|
+            # Skip passwords if resuming
+            if current_line < skip_count
+              current_line += 1
+              next
+            end
+            current_line += 1
             remaining_users = users.select { |u| u.password.nil? }
 
             break if remaining_users.empty?
@@ -49,7 +67,7 @@ module WPScan
                   user.password = password
 
                   begin
-                    progress_bar.total -= wordlist.count - user_requests_count[user.username]
+                    progress_bar.total -= effective_passwords - user_requests_count[user.username]
                   rescue ProgressBar::InvalidProgressError
                   end
 

--- a/lib/wpscan/finders/finder/breadth_first_dictionary_attack.rb
+++ b/lib/wpscan/finders/finder/breadth_first_dictionary_attack.rb
@@ -33,7 +33,6 @@ module WPScan
           # Keep the number of requests sent for each users
           # to be able to correctly update the progress when a password is found
           user_requests_count = {}
-          current_line = 0
 
           users.each { |u| user_requests_count[u.username] = 0 }
 
@@ -42,13 +41,7 @@ module WPScan
             progress_bar.log("[INFO] Skipping first #{skip_count} password(s) from wordlist...")
           end
 
-          File.foreach(wordlist, chomp: true) do |password|
-            # Skip passwords if resuming
-            if current_line < skip_count
-              current_line += 1
-              next
-            end
-            current_line += 1
+          File.foreach(wordlist, chomp: true).lazy.drop(skip_count).each do |password|
             remaining_users = users.select { |u| u.password.nil? }
 
             break if remaining_users.empty?

--- a/spec/app/controllers/password_attack_spec.rb
+++ b/spec/app/controllers/password_attack_spec.rb
@@ -34,7 +34,7 @@ describe WPScan::Controller::PasswordAttack do
 
     it 'contains to correct options' do
       expect(controller.cli_options.map(&:to_sym))
-        .to eq(%i[passwords usernames multicall_max_passwords password_attack login_uri])
+        .to eq(%i[passwords usernames multicall_max_passwords password_attack login_uri wordlist_skip])
     end
   end
 

--- a/spec/lib/finders/finder/breadth_first_dictionary_attack_spec.rb
+++ b/spec/lib/finders/finder/breadth_first_dictionary_attack_spec.rb
@@ -82,6 +82,48 @@ describe WPScan::Finders::Finder::BreadthFirstDictionaryAttack do
       end
     end
 
+    context 'when wordlist_skip is provided' do
+      context 'when skipping first password' do
+        before do
+          stub_request(:post, login_url)
+            .with(body: { username: 'admin', pwd: 'admin' })
+            .to_return(status: 302)
+        end
+
+        it 'skips the specified number of passwords and finds the valid one' do
+          expect { |block| finder.attack(users, wordlist_path, wordlist_skip: 1, &block) }
+            .to yield_with_args(WPScan::Model::User.new('admin', password: 'admin'))
+
+          # Verify that 'pwd' (first password) was not tried for any user
+          expect(a_request(:post, login_url).with(body: { username: 'admin', pwd: 'pwd' }))
+            .not_to have_been_made
+          expect(a_request(:post, login_url).with(body: { username: 'root', pwd: 'pwd' }))
+            .not_to have_been_made
+          expect(a_request(:post, login_url).with(body: { username: 'user', pwd: 'pwd' }))
+            .not_to have_been_made
+        end
+      end
+
+      context 'when skipping all passwords' do
+        it 'does not yield anything and makes no requests' do
+          expect { |block| finder.attack(users, wordlist_path, wordlist_skip: 3, &block) }
+            .not_to yield_control
+
+          # Verify no password attempts were made
+          expect(a_request(:post, login_url)).not_to have_been_made
+        end
+      end
+
+      context 'when skip count is larger than wordlist' do
+        it 'does not yield anything and makes no requests' do
+          expect { |block| finder.attack(users, wordlist_path, wordlist_skip: 100, &block) }
+            .not_to yield_control
+
+          expect(a_request(:post, login_url)).not_to have_been_made
+        end
+      end
+    end
+
     context 'when an error is present in a response' do
       before do
         if defined?(stub_params)


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Fixes #692

## Proposed changes

* Added new `--wordlist-skip N` CLI option to skip the first N passwords in a wordlist
* Modified `BreadthFirstDictionaryAttack#attack` to handle skipping passwords when resuming

```
[+] Performing password attack on Xmlrpc against 1 user/s
[INFO] Skipping first 950 password(s) from wordlist...
Trying initsogar / 1000 Time: 00:00:05 <======================================================> (50 / 50) 100.00% Time: 00:00:05
```

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When brute force attacks are interrupted (due to server restarts, network issues, or manual termination), users currently have no way to resume from where they left off without manually editing wordlist files.

This feature addresses a long-standing user request (#692) with strong community support (8+ comments over several years). The implementation provides a simple and intuitive way to resume interrupted attacks by specifying how many passwords to skip from the beginning of the wordlist.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. **Basic functionality test:**

   ```bash
   # Start a brute force attack and note the progress
   bundle exec ruby -Ilib bin/wpscan --url https://example.com --passwords wordlist.txt --usernames admin
   # Interrupt with Ctrl+C after some passwords are tried
   
   # Resume from where you left off (e.g., if 100 passwords were tried)
   bundle exec ruby -Ilib bin/wpscan --url https://example.com --passwords wordlist.txt --usernames admin --wordlist-skip 100
   ```

2. **Verify skipping works:**

   ```bash
   # Create a small test wordlist with numbered passwords
   echo -e "password1\\npassword2\\npassword3\\npassword4\\npassword5" > test.txt
   
   # Run with skip to verify first passwords are not attempted
   bundle exec ruby -Ilib bin/wpscan --url https://example.com --passwords test.txt --usernames admin --wordlist-skip 2
   # Should start from password3
   ```

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor grants Automattic Inc. the unlimited, non-exclusive right to reuse, modify, and relicense the code.

