### PR TITLE
Improved error messages about when database updates via cloudflare are making trouble.

### DIFF
--- a/lib/wpscan/db/updater.rb
+++ b/lib/wpscan/db/updater.rb
@@ -136,7 +136,8 @@ module WPScan
         FileUtils.rm(backup_file_path(filename))
       end
 
-      # @return [ String ] The checksum of the downloaded file
+      # @return [ Array(String, String) ] The checksum of the downloaded file and the
+      #                                    Cloudflare Ray ID of the response (or nil)
       def download(filename)
         file_path = local_file_path(filename)
         file_url  = remote_file_url(filename)
@@ -146,7 +147,7 @@ module WPScan
 
         File.binwrite(file_path, res.body)
 
-        local_file_checksum(filename)
+        [local_file_checksum(filename), res.headers && res.headers['CF-Ray']]
       end
 
       # @return [ Array<String> ] The filenames updated
@@ -160,9 +161,9 @@ module WPScan
           next if File.exist?(local_file_path(filename)) && db_checksum == local_file_checksum(filename)
 
           create_backup(filename)
-          dl_checksum = download(filename)
+          dl_checksum, cf_ray = download(filename)
 
-          raise Error::ChecksumsMismatch, filename unless dl_checksum == db_checksum
+          raise Error::ChecksumsMismatch.new(filename, cf_ray: cf_ray) unless dl_checksum == db_checksum
 
           updated << filename
         rescue StandardError => e

--- a/lib/wpscan/errors/http.rb
+++ b/lib/wpscan/errors/http.rb
@@ -31,7 +31,18 @@ module WPScan
     # Used in the Updater
     class Download < HTTP
       def to_s
-        "Unable to get #{failure_details}"
+        msg = "Unable to get #{failure_details}"
+
+        if response.effective_url.to_s.include?('data.wpscan.org')
+          cf_ray = response.headers && response.headers['CF-Ray']
+          msg += "\nCloudflare Ray ID: #{cf_ray}" if cf_ray
+          msg += "\nIf this issue persists, you can:\n  " \
+                 "- Check our status page at https://status.wpscan.com/\n  " \
+                 "- Contact us via https://wpscan.com/contact/ (please include the Ray ID above if any)\n  " \
+                 '- Or open a GitHub issue at https://github.com/wpscanteam/wpscan/issues'
+        end
+
+        msg
       end
     end
 

--- a/lib/wpscan/errors/update.rb
+++ b/lib/wpscan/errors/update.rb
@@ -10,14 +10,22 @@ module WPScan
     end
 
     class ChecksumsMismatch < Standard
-      attr_reader :db_file
+      attr_reader :db_file, :cf_ray
 
-      def initialize(db_file)
+      def initialize(db_file, cf_ray: nil)
         @db_file = db_file
+        @cf_ray  = cf_ray
+        super()
       end
 
       def to_s
-        "#{db_file}: checksums do not match. Please try again in a few minutes."
+        msg = "#{db_file}: checksums do not match. Please try again in a few minutes."
+        msg += "\nCloudflare Ray ID: #{cf_ray}" if cf_ray
+        msg += "\nIf this issue persists, you can:\n  " \
+               "- Check our status page at https://status.wpscan.com/\n  " \
+               "- Contact us via https://wpscan.com/contact/ (please include the Ray ID above if any)\n  " \
+               '- Or open a GitHub issue at https://github.com/wpscanteam/wpscan/issues'
+        msg
       end
     end
   end

--- a/spec/lib/errors/http_spec.rb
+++ b/spec/lib/errors/http_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+describe WPScan::Error::Download do
+  subject(:error) { described_class.new(response) }
+
+  let(:response) do
+    Typhoeus::Response.new(
+      effective_url: effective_url,
+      code: 503,
+      return_message: 'ok',
+      response_headers: response_headers
+    )
+  end
+  let(:response_headers) { '' }
+
+  describe '#to_s' do
+    context 'when the failing URL is on data.wpscan.org' do
+      let(:effective_url) { 'https://data.wpscan.org/metadata.json' }
+
+      it 'includes the URL, status, and the support guidance' do
+        msg = error.to_s
+
+        expect(msg).to include('https://data.wpscan.org/metadata.json')
+        expect(msg).to include('status: 503')
+        expect(msg).to include('https://status.wpscan.com/')
+        expect(msg).to include('https://wpscan.com/contact/')
+        expect(msg).to include('https://github.com/wpscanteam/wpscan/issues')
+      end
+
+      context 'when a CF-Ray header is set' do
+        let(:response_headers) { "HTTP/1.1 503 Service Unavailable\r\nCF-Ray: 8abc1234deadbeef-FRA\r\n\r\n" }
+
+        it 'surfaces the Cloudflare Ray ID' do
+          expect(error.to_s).to include('Cloudflare Ray ID: 8abc1234deadbeef-FRA')
+        end
+      end
+
+      context 'when no CF-Ray header is set' do
+        it 'does not mention a Ray ID' do
+          expect(error.to_s).not_to include('Cloudflare Ray ID')
+        end
+      end
+    end
+
+    context 'when the failing URL is not on data.wpscan.org' do
+      let(:effective_url) { 'https://example.com/file' }
+
+      it 'does not include the support guidance' do
+        msg = error.to_s
+
+        expect(msg).to include('https://example.com/file')
+        expect(msg).not_to include('status.wpscan.com')
+        expect(msg).not_to include('wpscan.com/contact')
+      end
+    end
+  end
+end

--- a/spec/lib/errors/update_spec.rb
+++ b/spec/lib/errors/update_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+describe WPScan::Error::ChecksumsMismatch do
+  describe '#to_s' do
+    context 'without a Cloudflare Ray ID' do
+      subject(:error) { described_class.new('metadata.json') }
+
+      it 'mentions the offending file and the support guidance, but no Ray ID' do
+        msg = error.to_s
+
+        expect(msg).to include('metadata.json')
+        expect(msg).to include('checksums do not match')
+        expect(msg).to include('https://status.wpscan.com/')
+        expect(msg).to include('https://wpscan.com/contact/')
+        expect(msg).to include('https://github.com/wpscanteam/wpscan/issues')
+        expect(msg).not_to include('Cloudflare Ray ID')
+      end
+    end
+
+    context 'with a Cloudflare Ray ID' do
+      subject(:error) { described_class.new('metadata.json', cf_ray: '8abc1234deadbeef-FRA') }
+
+      it 'surfaces the Ray ID' do
+        expect(error.to_s).to include('Cloudflare Ray ID: 8abc1234deadbeef-FRA')
+      end
+    end
+  end
+end


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Fixes https://github.com/wpscanteam/wpscan/issues/1681 - although not the entire WPScan.com API is servied via Cloudflare anymore (which this issue was originally about), we still do it for the database data served from data.wpscan.org; so it's a good idea to improve the error messaging here.

## Proposed changes

  * `Error::Download` and `Error::ChecksumsMismatch` now point users to the status page, contact form, and GitHub issues when the failure is against `data.wpscan.org`.
  * Both errors surface the Cloudflare Ray ID (`CF-Ray` header) when present.
  * Added focused specs under `spec/lib/errors/`.

  ## Why are these changes being made?

  * Partially addresses [#1681](https://github.com/wpscanteam/wpscan/issues/1681): the API no longer sits behind Cloudflare, but `data.wpscan.org` does, so DB-update failures are the remaining case worth improving.
  * The Ray ID lets anyone with Cloudflare account access correlate a user report to the exact edge log entry.

  ## Testing instructions

You can change what is returned from `WPScan::DB::Updater#local_file_checksum` or `WPScan::DB::Updater#remote_file_url` to reliably cause errors (then run `wpscan --update`).

