### PR TITLE
Stream output as we find things for plugins, themes, and users.

### DIFF
--- a/app/controllers/core/cli_options.rb
+++ b/app/controllers/core/cli_options.rb
@@ -16,6 +16,11 @@ module WPScan
           OptFilePath.new(['-o', '--output FILE', 'Output to FILE'], writable: true, exists: false),
           OptChoice.new(['-f', '--format FORMAT',
                          'Output results in the format supplied'], choices: formats),
+          OptBoolean.new(['--[no-]stream',
+                          'Emit enumeration findings (plugins/themes/users) as they are discovered, ' \
+                          'instead of waiting until each enumeration step completes. ' \
+                          'Has no effect on the json or sarif output formats, which always batch.'],
+                         default: true),
           OptChoice.new(['--detection-mode MODE'],
                         choices: %w[mixed passive aggressive],
                         normalize: :to_sym,

--- a/app/controllers/enumeration/enum_methods.rb
+++ b/app/controllers/enumeration/enum_methods.rb
@@ -4,6 +4,14 @@ module WPScan
   module Controller
     # Enumeration Methods
     class Enumeration < WPScan::Controller::Base
+      # @return [ Boolean ] Whether enumeration findings should be streamed
+      #   as they are discovered rather than batched at end of step. Streaming
+      #   requires both a streaming-capable formatter (cli, cli_no_color, jsonl)
+      #   and the user not having opted out via --no-stream.
+      def stream_findings?
+        formatter.streams? && ParsedCli.stream != false
+      end
+
       # @param [ String ] type (plugins or themes)
       # @param [ Symbol ] detection_mode
       #
@@ -116,20 +124,11 @@ module WPScan
         )
 
         output('@info', msg: enum_message('plugins', opts[:mode])) if user_interaction?
-        # Enumerate the plugins & find their versions to avoid doing that when #version
-        # is called in the view
-        plugins = target.plugins(opts)
 
-        if user_interaction? && !plugins.empty?
-          output('@info',
-                 msg: "Checking Plugin Versions #{enum_detection_message(opts[:version_detection][:mode])}")
-        end
-
-        plugins.each(&:version)
-
-        plugins.select!(&:vulnerable?) if ParsedCli.enumerate&.dig(:vulnerable_plugins)
-
-        output('plugins', plugins: plugins)
+        enum_wp_items(
+          'plugin', target_method: :plugins, opts: opts,
+                    only_vulnerable: ParsedCli.enumerate&.dig(:vulnerable_plugins)
+        )
       end
 
       # @param [ Hash ] opts
@@ -165,20 +164,56 @@ module WPScan
         )
 
         output('@info', msg: enum_message('themes', opts[:mode])) if user_interaction?
-        # Enumerate the themes & find their versions to avoid doing that when #version
-        # is called in the view
-        themes = target.themes(opts)
 
-        if user_interaction? && !themes.empty?
-          output('@info',
-                 msg: "Checking Theme Versions #{enum_detection_message(opts[:version_detection][:mode])}")
+        enum_wp_items(
+          'theme', target_method: :themes, opts: opts,
+                   only_vulnerable: ParsedCli.enumerate&.dig(:vulnerable_themes)
+        )
+      end
+
+      # Shared plugins/themes enumeration body. Streams per-item output when
+      # the active formatter supports it (and --no-stream wasn't passed),
+      # otherwise batches the result and renders the plural view.
+      #
+      # @param [ String ] singular  'plugin' or 'theme' (view name)
+      # @param [ Symbol ] target_method  :plugins or :themes
+      # @param [ Hash ] opts  Options forwarded to the target call
+      # @param [ Boolean ] only_vulnerable  Filter to vulnerable items only
+      def enum_wp_items(singular, target_method:, opts:, only_vulnerable:)
+        stream = stream_findings?
+
+        items = target.send(target_method, opts) do |item|
+          stream_wp_item(item, singular: singular, only_vulnerable: only_vulnerable) if stream
         end
 
-        themes.each(&:version)
+        finalize_wp_items_output(items, singular: singular, opts: opts, stream: stream,
+                                        only_vulnerable: only_vulnerable)
+      end
 
-        themes.select!(&:vulnerable?) if ParsedCli.enumerate&.dig(:vulnerable_themes)
+      def finalize_wp_items_output(items, singular:, opts:, stream:, only_vulnerable:)
+        plural = "#{singular}s"
 
-        output('themes', themes: themes)
+        if !stream && user_interaction? && !items.empty?
+          mode_msg = enum_detection_message(opts[:version_detection][:mode])
+          output('@info', msg: "Checking #{singular.capitalize} Versions #{mode_msg}")
+        end
+
+        items.each(&:version) unless stream
+        items.select!(&:vulnerable?) if only_vulnerable
+
+        if stream
+          summary = items.empty? ? "No #{plural} Found." : "#{items.size} #{singular}(s) Identified."
+          output('@notice', msg: summary)
+        else
+          output(plural, plural.to_sym => items)
+        end
+      end
+
+      def stream_wp_item(item, singular:, only_vulnerable:)
+        item.version
+        return if only_vulnerable && !item.vulnerable?
+
+        output(singular, singular.to_sym => item)
       end
 
       # @param [ Hash ] opts
@@ -244,7 +279,22 @@ module WPScan
         )
 
         output('@info', msg: "Enumerating Users #{enum_detection_message(opts[:mode])}") if user_interaction?
-        output('users', users: target.users(opts))
+
+        stream = stream_findings?
+        exclude = ParsedCli.exclude_usernames
+
+        users = target.users(opts) do |user|
+          next unless stream
+          next if exclude&.match?(user.username)
+
+          output('user', user: user)
+        end || []
+
+        if stream
+          output('@notice', msg: users.empty? ? 'No Users Found.' : "#{users.size} user(s) Identified.")
+        else
+          output('users', users: users)
+        end
       end
 
       # @return [ Range ] The user ids range to enumerate

--- a/app/finders/plugins/known_locations.rb
+++ b/app/finders/plugins/known_locations.rb
@@ -14,22 +14,32 @@ module WPScan
 
         # @param [ Hash ] opts
         # @option opts [ String ] :list
+        # @option opts [ Findings ] :found Shared findings collection passed by
+        #   BaseFinders#run_finder. We append directly into it as each plugin
+        #   is detected so that Findings#on_append fires during the hydra run,
+        #   enabling streaming output. Falls back to a local array when called
+        #   outside the framework (e.g. directly from specs).
         #
-        # @return [ Array<Plugin> ]
+        # @return [ Array<Plugin> ] Items appended this call (empty when
+        #   already streamed into opts[:found] to avoid double-appending).
         def aggressive(opts = {})
-          found = []
+          shared = opts[:found]
+          local  = shared ? nil : []
+          count  = 0
 
           enumerate(target_urls(opts), opts.merge(check_full_response: true)) do |res, slug|
             finding_opts = opts.merge(found_by: found_by,
                                       confidence: 80,
                                       interesting_entries: ["#{res.effective_url}, status: #{res.code}"])
 
-            found << Model::Plugin.new(slug, target, finding_opts)
+            plugin = Model::Plugin.new(slug, target, finding_opts)
+            (shared || local) << plugin
+            count += 1
 
-            raise Error::PluginsThresholdReached if opts[:threshold].positive? && found.size >= opts[:threshold]
+            raise Error::PluginsThresholdReached if opts[:threshold].positive? && count >= opts[:threshold]
           end
 
-          found
+          local || []
         end
 
         # @param [ Hash ] opts

--- a/app/finders/themes/known_locations.rb
+++ b/app/finders/themes/known_locations.rb
@@ -14,22 +14,28 @@ module WPScan
 
         # @param [ Hash ] opts
         # @option opts [ String ] :list
+        # @option opts [ Findings ] :found Shared findings collection; see
+        #   {Plugins::KnownLocations#aggressive} for the streaming rationale.
         #
         # @return [ Array<Theme> ]
         def aggressive(opts = {})
-          found = []
+          shared = opts[:found]
+          local  = shared ? nil : []
+          count  = 0
 
           enumerate(target_urls(opts), opts.merge(check_full_response: true)) do |res, slug|
             finding_opts = opts.merge(found_by: found_by,
                                       confidence: 80,
                                       interesting_entries: ["#{res.effective_url}, status: #{res.code}"])
 
-            found << Model::Theme.new(slug, target, finding_opts)
+            theme = Model::Theme.new(slug, target, finding_opts)
+            (shared || local) << theme
+            count += 1
 
-            raise Error::ThemesThresholdReached if opts[:threshold].positive? && found.size >= opts[:threshold]
+            raise Error::ThemesThresholdReached if opts[:threshold].positive? && count >= opts[:threshold]
           end
 
-          found
+          local || []
         end
 
         # @param [ Hash ] opts

--- a/app/finders/users/author_id_brute_forcing.rb
+++ b/app/finders/users/author_id_brute_forcing.rb
@@ -14,10 +14,13 @@ module WPScan
 
         # @param [ Hash ] opts
         # @option opts [ Range ] :range Mandatory
+        # @option opts [ Findings ] :found Shared findings collection; see
+        #   {Plugins::KnownLocations#aggressive} for the streaming rationale.
         #
         # @return [ Array<User> ]
         def aggressive(opts = {})
-          found = []
+          shared       = opts[:found]
+          local        = shared ? nil : []
           found_by_msg = 'Author Id Brute Forcing - %s (Aggressive Detection)'
 
           enumerate(target_urls(opts), opts.merge(check_full_response: true)) do |res, id|
@@ -25,15 +28,16 @@ module WPScan
 
             next unless username
 
-            found << Model::User.new(
+            user = Model::User.new(
               username,
               id: id,
               found_by: format(found_by_msg, found_by),
               confidence: confidence
             )
+            (shared || local) << user
           end
 
-          found
+          local || []
         end
 
         # @param [ Hash ] opts

--- a/app/formatters/cli.rb
+++ b/app/formatters/cli.rb
@@ -4,6 +4,10 @@ module WPScan
   module Formatter
     # CLI Formatter
     class Cli < Base
+      def streams?
+        true
+      end
+
       # @return [ String ]
       def info_icon
         green('[+]')

--- a/app/formatters/cli.rb
+++ b/app/formatters/cli.rb
@@ -8,6 +8,16 @@ module WPScan
         true
       end
 
+      # ANSI sequence to clear the current line and return to column 0.
+      # Emitted at the start of each streamed enumeration finding so the
+      # ruby-progressbar line (which redraws via \r and leaves its previous
+      # render visible when interleaved with foreign output) gets wiped
+      # before the finding prints. No-op on non-TTY stdout so file/pipe
+      # output stays clean.
+      def bar_clear
+        $stdout.tty? ? "\e[2K\r" : ''
+      end
+
       # @return [ String ]
       def info_icon
         green('[+]')

--- a/app/formatters/jsonl.rb
+++ b/app/formatters/jsonl.rb
@@ -11,6 +11,10 @@ module WPScan
         'json'
       end
 
+      def streams?
+        true
+      end
+
       def output(tpl, vars = {}, controller_name = nil)
         rendered = render(tpl, vars, controller_name)
                    .encode('UTF-8', invalid: :replace, undef: :replace)

--- a/app/views/cli/enumeration/plugin.erb
+++ b/app/views/cli/enumeration/plugin.erb
@@ -1,3 +1,4 @@
+<%= bar_clear -%>
 
 <%= info_icon %> <%= @plugin %>
 <%= render('@wp_item', wp_item: @plugin) -%>

--- a/app/views/cli/enumeration/plugin.erb
+++ b/app/views/cli/enumeration/plugin.erb
@@ -1,0 +1,12 @@
+
+<%= info_icon %> <%= @plugin %>
+<%= render('@wp_item', wp_item: @plugin) -%>
+ |
+<%= render('@finding', item: @plugin) -%>
+ |
+<% if @plugin.version -%>
+ | Version: <%= @plugin.version %> (<%= @plugin.version.confidence %>% confidence)
+<%= render('@finding', item: @plugin.version) -%>
+<% else -%>
+ | The version could not be determined.
+<% end -%>

--- a/app/views/cli/enumeration/plugins.erb
+++ b/app/views/cli/enumeration/plugins.erb
@@ -4,17 +4,6 @@
 <% else -%>
 <%= notice_icon %> Plugin(s) Identified:
 <% @plugins.each do |plugin| -%>
-
-<%= info_icon %> <%= plugin %>
-<%= render('@wp_item', wp_item: plugin) -%>
- |
-<%= render('@finding', item: plugin) -%>
- |
-<% if plugin.version -%>
- | Version: <%= plugin.version %> (<%= plugin.version.confidence %>% confidence)
-<%= render('@finding', item: plugin.version) -%>
-<% else -%>
- | The version could not be determined.
-<% end -%>
+<%= render('plugin', plugin: plugin) -%>
 <% end -%>
 <% end %>

--- a/app/views/cli/enumeration/theme.erb
+++ b/app/views/cli/enumeration/theme.erb
@@ -1,3 +1,4 @@
+<%= bar_clear -%>
 
 <%= info_icon %> <%= @theme %>
 <%= render('@theme', theme: @theme, show_parents: false) -%>

--- a/app/views/cli/enumeration/theme.erb
+++ b/app/views/cli/enumeration/theme.erb
@@ -1,0 +1,3 @@
+
+<%= info_icon %> <%= @theme %>
+<%= render('@theme', theme: @theme, show_parents: false) -%>

--- a/app/views/cli/enumeration/themes.erb
+++ b/app/views/cli/enumeration/themes.erb
@@ -4,8 +4,6 @@
 <% else -%>
 <%= notice_icon %> Theme(s) Identified:
 <% @themes.each do |theme| -%>
-
-<%= info_icon %> <%= theme %>
-<%= render('@theme', theme: theme, show_parents: false) -%>
+<%= render('theme', theme: theme) -%>
 <% end -%>
 <% end %>

--- a/app/views/cli/enumeration/user.erb
+++ b/app/views/cli/enumeration/user.erb
@@ -1,0 +1,3 @@
+
+<%= info_icon %> <%= @user %>
+<%= render('@finding', item: @user) -%>

--- a/app/views/cli/enumeration/user.erb
+++ b/app/views/cli/enumeration/user.erb
@@ -1,3 +1,4 @@
+<%= bar_clear -%>
 
 <%= info_icon %> <%= @user %>
 <%= render('@finding', item: @user) -%>

--- a/app/views/cli/enumeration/users.erb
+++ b/app/views/cli/enumeration/users.erb
@@ -4,8 +4,6 @@
 <% else -%>
 <%= notice_icon %> User(s) Identified:
 <% @users.each do |user| -%>
-
-<%= info_icon %> <%= user %>
-<%= render('@finding', item: user) -%>
+<%= render('user', user: user) -%>
 <% end -%>
 <% end %>

--- a/app/views/json/enumeration/plugin.erb
+++ b/app/views/json/enumeration/plugin.erb
@@ -1,0 +1,15 @@
+"plugin": {
+  <%= @plugin.slug.to_json %>: {
+    <%= render('@wp_item', wp_item: @plugin) %>,
+    <%= render('@finding', item: @plugin) -%>,
+    <% if @plugin.version -%>
+    "version": {
+      "number": <%= @plugin.version.number.to_json %>,
+      "confidence": <%= @plugin.version.confidence.to_json %>,
+      <%= render('@finding', item: @plugin.version) -%>
+    }
+    <% else -%>
+    "version": null
+    <% end -%>
+  }
+}

--- a/app/views/json/enumeration/theme.erb
+++ b/app/views/json/enumeration/theme.erb
@@ -1,0 +1,5 @@
+"theme": {
+  <%= @theme.slug.to_json %>: {
+    <%= render('@theme', theme: @theme) -%>
+  }
+}

--- a/app/views/json/enumeration/user.erb
+++ b/app/views/json/enumeration/user.erb
@@ -1,0 +1,6 @@
+"user": {
+  <%= @user.username.to_json %>: {
+    "id": <%= @user.id.to_json %>,
+    <%= render('@finding', item: @user) -%>
+  }
+}

--- a/lib/wpscan/finders/findings.rb
+++ b/lib/wpscan/finders/findings.rb
@@ -4,6 +4,11 @@ module WPScan
   module Finders
     # Findings container
     class Findings < Array
+      # Optional callable invoked with each newly-appended finding (not invoked
+      # when a duplicate is merged into an existing one via confirmed_by). Used
+      # by enumeration controllers to stream findings as they are discovered.
+      attr_accessor :on_append
+
       # Override to include the confirmed_by logic
       #
       # @param [ Finding ] finding
@@ -20,6 +25,8 @@ module WPScan
         end
 
         super
+        @on_append&.call(finding)
+        self
       end
     end
   end

--- a/lib/wpscan/finders/independent_finder.rb
+++ b/lib/wpscan/finders/independent_finder.rb
@@ -8,17 +8,20 @@ module WPScan
 
       # See ActiveSupport::Concern
       module ClassMethods
-        def find(target, opts = {})
-          new(target).find(opts)
+        def find(target, opts = {}, &)
+          new(target).find(opts, &)
         end
       end
 
       # @param [ Hash ] opts
       # @option opts [ Symbol ] mode (:mixed, :passive, :aggressive)
+      # @yield [ Finding ] Optional block called for each finding the moment
+      #                   it is first appended to the result set (used to
+      #                   stream enumeration findings as they are discovered).
       #
       # @return [ Findings ]
-      def find(opts = {})
-        finders.run(opts)
+      def find(opts = {}, &)
+        finders.run(opts, &)
       end
 
       # @return [ Array ]

--- a/lib/wpscan/finders/same_type_finders.rb
+++ b/lib/wpscan/finders/same_type_finders.rb
@@ -10,7 +10,9 @@ module WPScan
       # @option opts [ Boolean ] :sort Wether or not to sort the findings
       #
       # @return [ Findings ]
-      def run(opts = {})
+      def run(opts = {}, &block)
+        findings.on_append = block if block
+
         symbols_from_mode(opts[:mode]).each do |symbol|
           each do |finder|
             run_finder(finder, symbol, opts)

--- a/lib/wpscan/formatter.rb
+++ b/lib/wpscan/formatter.rb
@@ -66,6 +66,14 @@ module WPScan
         format == 'cli'
       end
 
+      # @return [ Boolean ]
+      # Whether this formatter can render findings incrementally as they
+      # arrive (cli, jsonl), or needs to receive the full result set first
+      # (json, sarif — they emit a single well-formed document at end-of-scan).
+      def streams?
+        false
+      end
+
       # @return [ String ] The underscored format to use as a base
       def base_format; end
 

--- a/lib/wpscan/target.rb
+++ b/lib/wpscan/target.rb
@@ -161,17 +161,21 @@ module WPScan
     end
 
     # @param [ Hash ] opts
+    # @yield [ Plugin ] Optional block called as each plugin is first
+    #                   discovered (used to stream findings).
     #
     # @return [ Array<Plugin> ]
-    def plugins(opts = {})
-      @plugins ||= Finders::Plugins::Base.find(self, opts)
+    def plugins(opts = {}, &)
+      @plugins ||= Finders::Plugins::Base.find(self, opts, &)
     end
 
     # @param [ Hash ] opts
+    # @yield [ Theme ] Optional block called as each theme is first
+    #                  discovered (used to stream findings).
     #
     # @return [ Array<Theme> ]
-    def themes(opts = {})
-      @themes ||= Finders::Themes::Base.find(self, opts)
+    def themes(opts = {}, &)
+      @themes ||= Finders::Themes::Base.find(self, opts, &)
     end
 
     # @param [ Hash ] opts
@@ -203,10 +207,12 @@ module WPScan
     end
 
     # @param [ Hash ] opts
+    # @yield [ User ] Optional block called as each user is first
+    #                 discovered (used to stream findings).
     #
     # @return [ Array<User> ]
-    def users(opts = {})
-      @users ||= Finders::Users::Base.find(self, opts)
+    def users(opts = {}, &)
+      @users ||= Finders::Users::Base.find(self, opts, &)
     end
   end
 end

--- a/spec/app/controllers/enumeration_spec.rb
+++ b/spec/app/controllers/enumeration_spec.rb
@@ -145,6 +145,80 @@ describe WPScan::Controller::Enumeration do
     end
   end
 
+  describe 'streaming output (issue #952)' do
+    # Stub two plugin finds; the stubbed target#plugins yields them through
+    # the block (mirroring how findings reach the controller from the finder
+    # layer) and also returns the array so post-processing still works.
+    let(:plugin1) { instance_double(WPScan::Model::Plugin, version: nil, vulnerable?: false) }
+    let(:plugin2) { instance_double(WPScan::Model::Plugin, version: nil, vulnerable?: true) }
+
+    let(:cli_args) { "#{super()} -e ap" }
+
+    before do
+      # Formatter is memoized in a class variable; reset so each example
+      # picks up the formatter implied by its --format CLI arg.
+      WPScan::Controller::Base.reset
+      WPScan::ParsedCli.options = rspec_parsed_options(cli_args)
+
+      allow(controller.target).to receive(:plugins) do |_opts, &block|
+        [plugin1, plugin2].each { |p| block&.call(p) }
+        [plugin1, plugin2]
+      end
+    end
+
+    context 'with a streaming formatter (cli)' do
+      it 'emits each plugin individually plus a summary notice' do
+        expect(controller.formatter).to receive(:output).with('@info', anything, 'enumeration').once
+        expect(controller.formatter).to receive(:output).with('plugin', hash_including(plugin: plugin1), 'enumeration')
+        expect(controller.formatter).to receive(:output).with('plugin', hash_including(plugin: plugin2), 'enumeration')
+        expect(controller.formatter).to receive(:output).with('@notice', hash_including(:msg), 'enumeration').once
+        expect(controller.formatter).not_to receive(:output).with('plugins', anything, anything)
+
+        controller.enum_plugins
+      end
+
+      context 'with -e vp (vulnerable_plugins) it streams only vulnerable findings' do
+        let(:cli_args) { "#{super().sub('-e ap', '-e vp')} --api-token x" }
+
+        before { allow(WPScan::DB::VulnApi).to receive(:token).and_return('x') }
+        after { WPScan::DB::VulnApi.token = nil }
+
+        it 'skips non-vulnerable plugins in the streamed output' do
+          expect(controller.formatter).to receive(:output).with('@info', anything, anything).once
+          expect(controller.formatter).not_to receive(:output).with('plugin', hash_including(plugin: plugin1), anything)
+          expect(controller.formatter).to receive(:output).with('plugin', hash_including(plugin: plugin2),
+                                                                'enumeration')
+          expect(controller.formatter).to receive(:output).with('@notice', hash_including(:msg), 'enumeration').once
+
+          controller.enum_plugins
+        end
+      end
+    end
+
+    context 'with --no-stream' do
+      let(:cli_args) { "#{super()} --no-stream" }
+
+      it 'falls back to the batched plural output' do
+        expect(controller.formatter).to receive(:output).with('@info', anything, 'enumeration').at_least(:once)
+        expect(controller.formatter).not_to receive(:output).with('plugin', anything, anything)
+        expect(controller.formatter).to receive(:output).with('plugins', hash_including(:plugins), 'enumeration').once
+
+        controller.enum_plugins
+      end
+    end
+
+    context 'with a non-streaming formatter (json)' do
+      let(:cli_args) { "#{super()} -f json" }
+
+      it 'uses the batched plural output regardless of --stream' do
+        expect(controller.formatter).not_to receive(:output).with('plugin', anything, anything)
+        expect(controller.formatter).to receive(:output).with('plugins', hash_including(:plugins), 'enumeration').once
+
+        controller.enum_plugins
+      end
+    end
+  end
+
   describe '#run' do
     context 'when no :enumerate' do
       it 'does not call any enum methods' do

--- a/spec/lib/finders/findings_spec.rb
+++ b/spec/lib/finders/findings_spec.rb
@@ -35,4 +35,35 @@ describe WPScan::Finders::Findings do
       end
     end
   end
+
+  describe '#on_append' do
+    it 'fires the callback for each newly appended finding' do
+      seen = []
+      findings.on_append = ->(f) { seen << f }
+
+      findings << finding.new('one')
+      findings << finding.new('two')
+
+      expect(seen.map(&:r)).to eq(%w[one two])
+    end
+
+    it 'does not fire when a duplicate is merged into an existing finding' do
+      seen = []
+      findings.on_append = ->(f) { seen << f }
+
+      findings << finding.new('dup')
+      findings << finding.new('dup')
+
+      expect(seen.size).to eq(1)
+    end
+
+    it 'does not fire for nil values' do
+      seen = []
+      findings.on_append = ->(f) { seen << f }
+
+      findings << nil
+
+      expect(seen).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Resolves https://github.com/wpscanteam/wpscan/issues/952

## Proposed changes

  - Enumeration findings (plugins, themes, users) now stream to stdout as each one is discovered, instead of being batched until the enumeration step finishes.
  - Added a `Formatter::Base#streams?` capability flag: `cli`, `cli_no_color` and `jsonl` opt in; `json` and `sarif` keep their batched single-document contract.
  - Split the per-item rendering out of `plugins.erb`/`themes.erb`/`users.erb` into singular `plugin.erb`/`theme.erb`/`user.erb` partials. Plural views delegate to them, so streamed and batched output stay
  byte-identical per item.
  - The CLI singular views emit an ANSI clear-line sequence (TTY only) before each finding so the ruby-progressbar line gets wiped instead of getting stuck in the middle of finding output.

  ## Why are these changes being made?

  - A long `--enumerate ap` run can take many minutes and previously produced no output until the very end. If the operator was rate-limited, lost connectivity, or hit Ctrl-C, all results so far were lost and the time was wasted.
  - `--no-stream` exists as an escape hatch for scripts that grep for the existing `[i] Plugin(s) Identified:` headline shape, or anyone who simply prefers the all-at-end format.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run an enumeration against a site that finds multiple things, for example with `-e p`.
- Verify by default it does stream on the CLI output (which is also default, so no extra parameters needed).
- Verify that passing `--no-stream` still has the previous behavior of not streaming and printing everything once the enumeration is done.
- Verify that it streams for `-f cli-no-color` and `-f jsonl` as well
- Verify that it does NOT stream for `-f json` and `-f sarif`

