### PR TITLE
Add --max-retries option for automatic retry of failed brute force requests

### DIFF
--- a/app/controllers/password_attack.rb
+++ b/app/controllers/password_attack.rb
@@ -24,6 +24,9 @@ module WPScan
           OptString.new(['--login-uri URI', 'The URI of the login page if different from /wp-login.php']),
           OptInteger.new(['--wordlist-skip N',
                           'Skip the first N passwords in the wordlist (resume from line N+1)'],
+                         default: 0),
+          OptInteger.new(['--max-retries N',
+                          'Maximum retry attempts for failed requests due to network/proxy errors'],
                          default: 0)
         ]
       end
@@ -32,7 +35,8 @@ module WPScan
         @attack_opts ||= {
           show_progression: user_interaction?,
           multicall_max_passwords: ParsedCli.multicall_max_passwords,
-          wordlist_skip: ParsedCli.wordlist_skip
+          wordlist_skip: ParsedCli.wordlist_skip,
+          max_retries: ParsedCli.max_retries
         }
       end
 

--- a/lib/wpscan/finders/finder/breadth_first_dictionary_attack.rb
+++ b/lib/wpscan/finders/finder/breadth_first_dictionary_attack.rb
@@ -10,6 +10,7 @@ module WPScan
         # @param [ Hash ] opts
         # @option opts [ Boolean ] :show_progression
         # @option opts [ Integer ] :wordlist_skip Number of passwords to skip from the beginning
+        # @option opts [ Integer ] :max_retries Maximum retry attempts for failed requests
         #
         # @yield [ WPScan::User ] When a valid combination is found
         #
@@ -22,6 +23,7 @@ module WPScan
         def attack(users, wordlist_path, opts = {})
           wordlist = File.open(wordlist_path)
           skip_count = opts[:wordlist_skip] || 0
+          max_retries = opts[:max_retries] || 0
 
           # Calculate total, accounting for skipped passwords
           total_passwords = wordlist.count
@@ -33,6 +35,8 @@ module WPScan
           # Keep the number of requests sent for each users
           # to be able to correctly update the progress when a password is found
           user_requests_count = {}
+          # Track retry attempts for each user/password combination
+          retry_count = Hash.new { |h, k| h[k] = Hash.new(0) }
 
           users.each { |u| user_requests_count[u.username] = 0 }
 
@@ -47,30 +51,9 @@ module WPScan
             break if remaining_users.empty?
 
             remaining_users.each do |user|
-              request = login_request(user.username, password)
-
-              user_requests_count[user.username] += 1
-
-              request.on_complete do |res|
-                progress_bar.title = "Trying #{user.username} / #{password}"
-
-                progress_bar.increment unless progress_bar.progress == progress_bar.total
-
-                if valid_credentials?(res)
-                  user.password = password
-
-                  begin
-                    progress_bar.total -= effective_passwords - user_requests_count[user.username]
-                  rescue ProgressBar::InvalidProgressError
-                  end
-
-                  yield user
-                elsif errored_response?(res)
-                  output_error(res)
-                end
+              queue_login_request(user, password, user_requests_count, retry_count, max_retries, effective_passwords, opts) do |found_user|
+                yield found_user if block_given?
               end
-
-              hydra.queue(request)
               queue_count += 1
 
               if queue_count >= hydra.max_concurrency
@@ -82,6 +65,67 @@ module WPScan
 
           hydra.run
           progress_bar.stop
+        end
+        # rubocop:enable all
+
+        # Queue a login request with retry support
+        #
+        # @param [ WPScan::Model::User ] user
+        # @param [ String ] password
+        # @param [ Hash ] user_requests_count
+        # @param [ Hash ] retry_count
+        # @param [ Integer ] max_retries
+        # @param [ Integer ] effective_passwords Total passwords accounting for skip
+        # @param [ Hash ] opts
+        #
+        # rubocop:disable all
+        def queue_login_request(user, password, user_requests_count, retry_count, max_retries, effective_passwords, opts, &block)
+          request = login_request(user.username, password)
+
+          user_requests_count[user.username] += 1
+
+          request.on_complete do |res|
+            retry_key = "#{user.username}:#{password}"
+            current_retry = retry_count[user.username][password]
+
+            progress_bar.title = "Trying #{user.username} / #{password}" +
+                                 (current_retry > 0 ? " (retry #{current_retry}/#{max_retries})" : "")
+
+            if valid_credentials?(res)
+              # Success - found valid credentials
+              progress_bar.increment unless progress_bar.progress == progress_bar.total
+
+              user.password = password
+
+              begin
+                progress_bar.total -= effective_passwords - user_requests_count[user.username]
+              rescue ProgressBar::InvalidProgressError
+              end
+
+              yield user if block_given?
+            elsif errored_response?(res)
+              # Error response - potentially retryable
+              if current_retry < max_retries
+                # Retry the request
+                retry_count[user.username][password] += 1
+
+                if opts[:show_progression]
+                  progress_bar.log("[RETRY #{retry_count[user.username][password]}/#{max_retries}] #{user.username} / #{password}")
+                end
+
+                queue_login_request(user, password, user_requests_count, retry_count, max_retries, effective_passwords, opts, &block)
+              else
+                # Max retries exhausted, log error and move on
+                output_error(res)
+                progress_bar.increment unless progress_bar.progress == progress_bar.total
+              end
+            else
+              # Invalid credentials (normal case) - just increment progress
+              progress_bar.increment unless progress_bar.progress == progress_bar.total
+            end
+          end
+
+          hydra.queue(request)
         end
         # rubocop:enable all
 

--- a/lib/wpscan/finders/finder/breadth_first_dictionary_attack.rb
+++ b/lib/wpscan/finders/finder/breadth_first_dictionary_attack.rb
@@ -109,7 +109,7 @@ module WPScan
                 # Retry the request
                 retry_count[user.username][password] += 1
 
-                if opts[:show_progression]
+                if opts[:show_progression] && WPScan::ParsedCli.verbose?
                   progress_bar.log("[RETRY #{retry_count[user.username][password]}/#{max_retries}] #{user.username} / #{password}")
                 end
 

--- a/lib/wpscan/finders/finder/breadth_first_dictionary_attack.rb
+++ b/lib/wpscan/finders/finder/breadth_first_dictionary_attack.rb
@@ -99,6 +99,11 @@ module WPScan
           end
 
           def handle_error(response, &)
+            if @user.password
+              @config.tracker.increment
+              return
+            end
+
             if should_retry?
               retry_attempt(&)
             else
@@ -107,7 +112,7 @@ module WPScan
           end
 
           def should_retry?
-            @retry_count < @max_retries && @user.password.nil?
+            @retry_count < @max_retries
           end
 
           def retry_attempt(&)

--- a/lib/wpscan/finders/finder/breadth_first_dictionary_attack.rb
+++ b/lib/wpscan/finders/finder/breadth_first_dictionary_attack.rb
@@ -5,6 +5,131 @@ module WPScan
     class Finder
       # Module to provide an easy way to perform password attacks
       module BreadthFirstDictionaryAttack
+        # Tracks progress for password attack
+        class ProgressTracker
+          attr_reader :progress_bar
+
+          def initialize(progress_bar:, total_passwords:)
+            @progress_bar = progress_bar
+            @total_passwords = total_passwords
+            @user_requests_count = Hash.new(0)
+          end
+
+          def record_request(username)
+            @user_requests_count[username] += 1
+          end
+
+          def requests_for_user(username)
+            @user_requests_count[username]
+          end
+
+          def update_title(username, password, retry_count, max_retries)
+            retry_info = retry_count.positive? ? " (retry #{retry_count}/#{max_retries})" : ''
+            @progress_bar.title = "Trying #{username} / #{password}#{retry_info}"
+          end
+
+          def increment
+            @progress_bar.increment unless @progress_bar.progress == @progress_bar.total
+          end
+
+          def adjust_total_on_success(username)
+            @progress_bar.total -= @total_passwords - @user_requests_count[username]
+          rescue ProgressBar::InvalidProgressError
+            # Due to Typhoeus threads, progress bar might be in invalid state
+          end
+
+          def log(message)
+            @progress_bar.log(message)
+          end
+
+          def stop
+            @progress_bar.stop
+          end
+        end
+
+        # Configuration bundle for LoginAttempt
+        LoginConfig = Struct.new(:tracker, :request_builder, :credentials_validator,
+                                 :error_checker, :error_handler, :hydra, :opts,
+                                 keyword_init: true)
+
+        # Handles a single login attempt with retry support
+        class LoginAttempt
+          attr_reader :user, :password, :max_retries
+          attr_accessor :retry_count
+
+          def initialize(user:, password:, max_retries:, config:)
+            @user = user
+            @password = password
+            @max_retries = max_retries
+            @retry_count = 0
+            @config = config
+          end
+
+          def execute(&block)
+            request = @config.request_builder.call(@user.username, @password)
+            @config.tracker.record_request(@user.username)
+
+            request.on_complete do |response|
+              handle_response(response, &block)
+            end
+
+            @config.hydra.queue(request)
+          end
+
+          private
+
+          def handle_response(response, &)
+            @config.tracker.update_title(@user.username, @password, @retry_count, @max_retries)
+
+            if @config.credentials_validator.call(response)
+              handle_success(&)
+            elsif @config.error_checker.call(response)
+              handle_error(response, &)
+            else
+              handle_invalid_credentials
+            end
+          end
+
+          def handle_success
+            @config.tracker.increment
+            @user.password = @password
+            @config.tracker.adjust_total_on_success(@user.username)
+
+            yield @user if block_given?
+          end
+
+          def handle_error(response, &)
+            if should_retry?
+              retry_attempt(&)
+            else
+              finalize_failed_attempt(response)
+            end
+          end
+
+          def should_retry?
+            @retry_count < @max_retries && @user.password.nil?
+          end
+
+          def retry_attempt(&)
+            @retry_count += 1
+
+            if @config.opts[:show_progression] && WPScan::ParsedCli.verbose?
+              @config.tracker.log("[RETRY #{@retry_count}/#{@max_retries}] #{@user.username} / #{@password}")
+            end
+
+            execute(&)
+          end
+
+          def finalize_failed_attempt(response)
+            @config.error_handler.call(response)
+            @config.tracker.increment
+          end
+
+          def handle_invalid_credentials
+            @config.tracker.increment
+          end
+        end
+
         # @param [ Array<WPScan::Model::User> ] users
         # @param [ String ] wordlist_path
         # @param [ Hash ] opts
@@ -30,30 +155,23 @@ module WPScan
           effective_passwords = [total_passwords - skip_count, 0].max
 
           create_progress_bar(total: users.size * effective_passwords, show_progression: opts[:show_progression])
-
-          queue_count         = 0
-          # Keep the number of requests sent for each users
-          # to be able to correctly update the progress when a password is found
-          user_requests_count = {}
-          # Track retry attempts for each user/password combination
-          retry_count = Hash.new { |h, k| h[k] = Hash.new(0) }
-
-          users.each { |u| user_requests_count[u.username] = 0 }
+          tracker = ProgressTracker.new(progress_bar: progress_bar, total_passwords: effective_passwords)
+          config = create_login_config(tracker, opts)
 
           # Show skip progress if skipping
-          if skip_count > 0 && opts[:show_progression]
-            progress_bar.log("[INFO] Skipping first #{skip_count} password(s) from wordlist...")
+          if skip_count.positive? && opts[:show_progression]
+            tracker.log("[INFO] Skipping first #{skip_count} password(s) from wordlist...")
           end
+
+          queue_count = 0
 
           File.foreach(wordlist, chomp: true).lazy.drop(skip_count).each do |password|
             remaining_users = users.select { |u| u.password.nil? }
-
             break if remaining_users.empty?
 
             remaining_users.each do |user|
-              queue_login_request(user, password, user_requests_count, retry_count, max_retries, effective_passwords, opts) do |found_user|
-                yield found_user if block_given?
-              end
+              attempt = LoginAttempt.new(user: user, password: password, max_retries: max_retries, config: config)
+              attempt.execute { |found_user| yield found_user if block_given? }
               queue_count += 1
 
               if queue_count >= hydra.max_concurrency
@@ -64,78 +182,28 @@ module WPScan
           end
 
           hydra.run
-          progress_bar.stop
+          tracker.stop
         end
         # rubocop:enable all
 
-        # Queue a login request with retry support
+        # Create login configuration with all dependencies
         #
-        # @param [ WPScan::Model::User ] user
-        # @param [ String ] password
-        # @param [ Hash ] user_requests_count
-        # @param [ Hash ] retry_count
-        # @param [ Integer ] max_retries
-        # @param [ Integer ] effective_passwords Total passwords accounting for skip
+        # @param [ ProgressTracker ] tracker
         # @param [ Hash ] opts
         #
-        # rubocop:disable all
-        def queue_login_request(user, password, user_requests_count, retry_count, max_retries, effective_passwords, opts, &block)
-          request = login_request(user.username, password)
-
-          user_requests_count[user.username] += 1
-
-          request.on_complete do |res|
-            current_retry = retry_count[user.username][password]
-
-            progress_bar.title = "Trying #{user.username} / #{password}" +
-                                 (current_retry > 0 ? " (retry #{current_retry}/#{max_retries})" : "")
-
-            if valid_credentials?(res)
-              # Success - found valid credentials
-              progress_bar.increment unless progress_bar.progress == progress_bar.total
-
-              user.password = password
-
-              begin
-                progress_bar.total -= effective_passwords - user_requests_count[user.username]
-              rescue ProgressBar::InvalidProgressError
-              end
-
-              # Clean up retry history for this user to free memory
-              retry_count.delete(user.username)
-
-              yield user if block_given?
-            elsif errored_response?(res)
-              # Error response - potentially retryable
-              if current_retry < max_retries && user.password.nil?
-                # Retry the request
-                retry_count[user.username][password] += 1
-
-                if opts[:show_progression] && WPScan::ParsedCli.verbose?
-                  progress_bar.log("[RETRY #{retry_count[user.username][password]}/#{max_retries}] #{user.username} / #{password}")
-                end
-
-                queue_login_request(user, password, user_requests_count, retry_count, max_retries, effective_passwords, opts, &block)
-              else
-                # Max retries exhausted, log error and move on
-                output_error(res)
-                progress_bar.increment unless progress_bar.progress == progress_bar.total
-
-                # Clean up retry count for this password since we're done with it
-                retry_count[user.username]&.delete(password)
-              end
-            else
-              # Invalid credentials (normal case) - just increment progress
-              progress_bar.increment unless progress_bar.progress == progress_bar.total
-
-              # Clean up retry count for this password since we're done with it
-              retry_count[user.username]&.delete(password)
-            end
-          end
-
-          hydra.queue(request)
+        # @return [ LoginConfig ]
+        #
+        def create_login_config(tracker, opts)
+          LoginConfig.new(
+            tracker: tracker,
+            request_builder: method(:login_request).to_proc,
+            credentials_validator: method(:valid_credentials?).to_proc,
+            error_checker: method(:errored_response?).to_proc,
+            error_handler: method(:output_error).to_proc,
+            hydra: hydra,
+            opts: opts
+          )
         end
-        # rubocop:enable all
 
         # @param [ String ] username
         # param [ String ] password

--- a/lib/wpscan/finders/finder/breadth_first_dictionary_attack.rb
+++ b/lib/wpscan/finders/finder/breadth_first_dictionary_attack.rb
@@ -67,7 +67,7 @@ module WPScan
 
           def execute(&block)
             request = @config.request_builder.call(@user.username, @password)
-            @config.tracker.record_request(@user.username)
+            @config.tracker.record_request(@user.username) if @retry_count.zero?
 
             request.on_complete do |response|
               handle_response(response, &block)

--- a/lib/wpscan/finders/finder/breadth_first_dictionary_attack.rb
+++ b/lib/wpscan/finders/finder/breadth_first_dictionary_attack.rb
@@ -85,7 +85,6 @@ module WPScan
           user_requests_count[user.username] += 1
 
           request.on_complete do |res|
-            retry_key = "#{user.username}:#{password}"
             current_retry = retry_count[user.username][password]
 
             progress_bar.title = "Trying #{user.username} / #{password}" +

--- a/lib/wpscan/finders/finder/breadth_first_dictionary_attack.rb
+++ b/lib/wpscan/finders/finder/breadth_first_dictionary_attack.rb
@@ -101,10 +101,13 @@ module WPScan
               rescue ProgressBar::InvalidProgressError
               end
 
+              # Clean up retry history for this user to free memory
+              retry_count.delete(user.username)
+
               yield user if block_given?
             elsif errored_response?(res)
               # Error response - potentially retryable
-              if current_retry < max_retries
+              if current_retry < max_retries && user.password.nil?
                 # Retry the request
                 retry_count[user.username][password] += 1
 
@@ -117,10 +120,16 @@ module WPScan
                 # Max retries exhausted, log error and move on
                 output_error(res)
                 progress_bar.increment unless progress_bar.progress == progress_bar.total
+
+                # Clean up retry count for this password since we're done with it
+                retry_count[user.username]&.delete(password)
               end
             else
               # Invalid credentials (normal case) - just increment progress
               progress_bar.increment unless progress_bar.progress == progress_bar.total
+
+              # Clean up retry count for this password since we're done with it
+              retry_count[user.username]&.delete(password)
             end
           end
 

--- a/spec/app/controllers/password_attack_spec.rb
+++ b/spec/app/controllers/password_attack_spec.rb
@@ -34,7 +34,7 @@ describe WPScan::Controller::PasswordAttack do
 
     it 'contains to correct options' do
       expect(controller.cli_options.map(&:to_sym))
-        .to eq(%i[passwords usernames multicall_max_passwords password_attack login_uri wordlist_skip])
+        .to eq(%i[passwords usernames multicall_max_passwords password_attack login_uri wordlist_skip max_retries])
     end
   end
 

--- a/spec/lib/finders/finder/breadth_first_dictionary_attack_spec.rb
+++ b/spec/lib/finders/finder/breadth_first_dictionary_attack_spec.rb
@@ -16,7 +16,8 @@ describe WPScan::Finders::Finder::BreadthFirstDictionaryAttack do
     end
 
     def errored_response?(response)
-      response.timed_out? || response.body.include?('Error:')
+      response.timed_out? || response.code.zero? ||
+        response.code.to_s.start_with?('5') || response.body.include?('Error:')
     end
   end
 
@@ -189,6 +190,98 @@ describe WPScan::Finders::Finder::BreadthFirstDictionaryAttack do
             expect(finder.progress_bar.log).to eql [
               "Error: Unknown response received Code: 200\nBody: Error: Something went wrong"
             ]
+          end
+        end
+      end
+    end
+
+    context 'when max_retries is provided' do
+      let(:users) { [WPScan::Model::User.new('admin')] }
+
+      context 'when request succeeds after retry' do
+        before do
+          # First attempt times out, second succeeds
+          stub_request(:post, login_url)
+            .with(body: { username: 'admin', pwd: 'pwd' })
+            .to_timeout
+            .then
+            .to_return(status: 302, headers: { 'Set-Cookie' => 'wordpress_logged_in_hash=valid' })
+        end
+
+        it 'retries and finds valid credentials' do
+          expect { |block| finder.attack(users, wordlist_path, max_retries: 2, show_progression: true, &block) }
+            .to yield_with_args(WPScan::Model::User.new('admin', password: 'pwd'))
+        end
+      end
+
+      context 'when max retries exhausted' do
+        before do
+          # All attempts timeout
+          stub_request(:post, login_url)
+            .with(body: { username: 'admin', pwd: 'pwd' })
+            .to_timeout
+        end
+
+        it 'exhausts retries and logs final error' do
+          finder.attack(users, wordlist_path, max_retries: 2)
+
+          # Final error should be logged
+          expect(finder.progress_bar.log).to eql(['Error: Request timed out.'])
+        end
+
+        it 'does not yield' do
+          expect { |block| finder.attack(users, wordlist_path, max_retries: 2, &block) }
+            .not_to yield_control
+        end
+      end
+
+      context 'when max_retries is 0 (default)' do
+        before do
+          stub_request(:post, login_url)
+            .with(body: { username: 'admin', pwd: 'pwd' })
+            .to_timeout
+        end
+
+        it 'does not retry' do
+          finder.attack(users, wordlist_path, max_retries: 0)
+
+          # Should only have error message, no retry messages
+          expect(finder.progress_bar.log).to eql(['Error: Request timed out.'])
+        end
+      end
+
+      context 'when different error types' do
+        let(:users) { [WPScan::Model::User.new('admin')] }
+
+        context 'connection error with retry' do
+          before do
+            # First attempt fails with connection error, second succeeds
+            stub_request(:post, login_url)
+              .with(body: { username: 'admin', pwd: 'pwd' })
+              .to_return(status: 0, body: '')
+              .then
+              .to_return(status: 302, headers: { 'Set-Cookie' => 'wordpress_logged_in_hash=valid' })
+          end
+
+          it 'retries and succeeds' do
+            expect { |block| finder.attack(users, wordlist_path, max_retries: 1, &block) }
+              .to yield_with_args(WPScan::Model::User.new('admin', password: 'pwd'))
+          end
+        end
+
+        context 'server error with retry' do
+          before do
+            # First attempt gets 500 error, second succeeds
+            stub_request(:post, login_url)
+              .with(body: { username: 'admin', pwd: 'pwd' })
+              .to_return(status: 500, body: 'Internal Server Error')
+              .then
+              .to_return(status: 302, headers: { 'Set-Cookie' => 'wordpress_logged_in_hash=valid' })
+          end
+
+          it 'retries and succeeds' do
+            expect { |block| finder.attack(users, wordlist_path, max_retries: 1, &block) }
+              .to yield_with_args(WPScan::Model::User.new('admin', password: 'pwd'))
           end
         end
       end


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Fixes #800

## Proposed changes

* Added new `--max-retries N` CLI option to automatically retry failed brute force requests
* Modified `BreadthFirstDictionaryAttack#attack` to implement retry logic with configurable maximum attempts
* Added `queue_login_request` helper method to handle retry logic and progress tracking
* Updated progress bar to show retry attempts when `show_progression` is enabled

<img width="1908" height="208" alt="CleanShot 2026-05-12 at 15 50 43@2x" src="https://github.com/user-attachments/assets/d07a9524-8cb1-4b74-82b0-4fb2fa8a8c7f" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

When performing brute force attacks through proxies or unstable networks, transient failures (timeouts, proxy errors, connection failures) cause passwords to be skipped without being properly tested. 

This feature addresses a long-standing user request (#800, opened in 2015) by providing automatic retry capability for failed requests. The implementation distinguishes between actual authentication failures and network/proxy errors, only retrying the latter. This ensures that valid credentials aren't missed due to transient network issues while maintaining backward compatibility (default: 0 retries).

The feature integrates seamlessly with the existing `--wordlist-skip` option, allowing users to both resume interrupted attacks and handle transient failures automatically.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This is a tricky one to test since we need an unstable environment or forcing it by stopping/restarting your web server in the middle of a long-running scan. Or you can just trust the CI.

```
bundle exec ruby -Ilib bin/wpscan --url https://example.com --passwords wordlist.txt --usernames admin --max-retries 3
```

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor grants Automattic Inc. the unlimited, non-exclusive right to reuse, modify, and relicense the code.

