### PR TITLE
XDG support for config base directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,7 +196,9 @@ WebMock adapter has custom port normalization for Typhoeus (spec/spec_helper.rb:
 
 **Configuration Files:**
 WPScan loads options from (in order):
-1. `~/.wpscan/scan.json` or `~/.wpscan/scan.yml`
-2. `pwd/.wpscan/scan.json` or `pwd/.wpscan/scan.yml`
+1. `$XDG_CONFIG_HOME/wpscan/scan.json` or `$XDG_CONFIG_HOME/wpscan/scan.yml`
+2. `~/.config/wpscan/scan.json` or `~/.config/wpscan/scan.yml`
+3. `~/.wpscan/scan.json` or `~/.wpscan/scan.yml`
+4. `pwd/.wpscan/scan.json` or `pwd/.wpscan/scan.yml`
 
 Use snake_case for CLI options in config (e.g., `api_token`, `max_threads`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,8 +196,8 @@ WebMock adapter has custom port normalization for Typhoeus (spec/spec_helper.rb:
 
 **Configuration Files:**
 WPScan loads options from (in order):
-1. `$XDG_CONFIG_HOME/wpscan/scan.json` or `$XDG_CONFIG_HOME/wpscan/scan.yml`
-2. `~/.config/wpscan/scan.json` or `~/.config/wpscan/scan.yml`
+1. `$XDG_CONFIG_HOME/wpscan/scan.json` or `$XDG_CONFIG_HOME/wpscan/scan.yml` (if `XDG_CONFIG_HOME` is set)
+2. `~/.config/wpscan/scan.json` or `~/.config/wpscan/scan.yml` (if `XDG_CONFIG_HOME` is not set)
 3. `~/.wpscan/scan.json` or `~/.wpscan/scan.yml`
 4. `pwd/.wpscan/scan.json` or `pwd/.wpscan/scan.yml`
 

--- a/README.md
+++ b/README.md
@@ -152,10 +152,10 @@ Up to **25** API requests per day are given free of charge, that should be suita
 
 WPScan can load all options (including the `--url`) from configuration files, the following locations are checked (order: first to last):
 
-- `$XDG_CONFIG_HOME/wpscan/scan.json`
-- `$XDG_CONFIG_HOME/wpscan/scan.yml`
-- `~/.config/wpscan/scan.json`
-- `~/.config/wpscan/scan.yml`
+- `$XDG_CONFIG_HOME/wpscan/scan.json` (if `XDG_CONFIG_HOME` is set)
+- `$XDG_CONFIG_HOME/wpscan/scan.yml` (if `XDG_CONFIG_HOME` is set)
+- `~/.config/wpscan/scan.json` (if `XDG_CONFIG_HOME` is not set)
+- `~/.config/wpscan/scan.yml` (if `XDG_CONFIG_HOME` is not set)
 - `~/.wpscan/scan.json`
 - `~/.wpscan/scan.yml`
 - `pwd/.wpscan/scan.json`

--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ Up to **25** API requests per day are given free of charge, that should be suita
 
 WPScan can load all options (including the `--url`) from configuration files, the following locations are checked (order: first to last):
 
+- `$XDG_CONFIG_HOME/wpscan/scan.json`
+- `$XDG_CONFIG_HOME/wpscan/scan.yml`
+- `~/.config/wpscan/scan.json`
+- `~/.config/wpscan/scan.yml`
 - `~/.wpscan/scan.json`
 - `~/.wpscan/scan.yml`
 - `pwd/.wpscan/scan.json`
@@ -161,7 +165,7 @@ If those files exist, options from the `cli_options` key will be loaded and over
 
 e.g:
 
-`~/.wpscan/scan.yml`:
+`~/.config/wpscan/scan.yml`:
 
 ```yml
 cli_options:
@@ -189,7 +193,7 @@ cli_options:
 
 ## Save API Token in a file
 
-The feature mentioned above is useful to keep the API Token in a config file and not have to supply it via the CLI each time. To do so, create the ~/.wpscan/scan.yml file containing the below:
+The feature mentioned above is useful to keep the API Token in a config file and not have to supply it via the CLI each time. To do so, create the ~/.config/wpscan/scan.yml file containing the below:
 
 ```yml
 cli_options:

--- a/lib/wpscan/controllers.rb
+++ b/lib/wpscan/controllers.rb
@@ -20,7 +20,7 @@ module WPScan
       ## XDG path
       [ENV['XDG_CONFIG_HOME', Pathname.new(Dir.home).join('.config')], ].each do |dir|
         option_parser.config_files.class.supported_extensions.each do |ext|
-          option_parser.config_files << Pathname.new(dir).join("#{WPScan.app_name}", "scan.#{ext}").to_s
+          option_parser.config_files << Pathname.new(dir).join(WPScan.app_name, "scan.#{ext}").to_s
         end
       end
       ## legacy path + working directory

--- a/lib/wpscan/controllers.rb
+++ b/lib/wpscan/controllers.rb
@@ -16,18 +16,17 @@ module WPScan
 
     # Registers the potential option-file paths with the option_parser.
     def register_config_files
-      # XDG support for config base directory
-      ## XDG path
-      [ENV['XDG_CONFIG_HOME'],  Pathname.new(Dir.home).join('.config')].each do |dir|
-        option_parser.config_files.class.supported_extensions.each do |ext|
-          option_parser.config_files << Pathname.new(dir).join(WPScan.app_name, "scan.#{ext}").to_s
-        end
-      end
-      ## legacy path + working directory
-      [Dir.home, Dir.pwd].each do |dir|
-        option_parser.config_files.class.supported_extensions.each do |ext|
-          option_parser.config_files << Pathname.new(dir).join(".#{WPScan.app_name}", "scan.#{ext}").to_s
-        end
+      # XDG Base Directory support for configuration
+      # https://specifications.freedesktop.org/basedir/latest/
+      xdg = ENV.fetch('XDG_CONFIG_HOME', nil)
+      xdg = Pathname.new(Dir.home).join('.config') if xdg.nil? || xdg.empty?
+      app = WPScan.app_name
+
+      dirs = [[xdg, app], [Dir.home, ".#{app}"], [Dir.pwd, ".#{app}"]]
+      exts = option_parser.config_files.class.supported_extensions
+
+      dirs.product(exts).each do |(dir, sub), ext|
+        option_parser.config_files << Pathname.new(dir).join(sub, "scan.#{ext}").to_s
       end
     end
 

--- a/lib/wpscan/controllers.rb
+++ b/lib/wpscan/controllers.rb
@@ -18,7 +18,7 @@ module WPScan
     def register_config_files
       # XDG support for config base directory
       ## XDG path
-      [ENV['XDG_CONFIG_HOME', Pathname.new(Dir.home).join('.config')], ].each do |dir|
+      [ENV['XDG_CONFIG_HOME', Pathname.new(Dir.home).join('.config')]].each do |dir|
         option_parser.config_files.class.supported_extensions.each do |ext|
           option_parser.config_files << Pathname.new(dir).join(WPScan.app_name, "scan.#{ext}").to_s
         end

--- a/lib/wpscan/controllers.rb
+++ b/lib/wpscan/controllers.rb
@@ -18,7 +18,7 @@ module WPScan
     def register_config_files
       # XDG support for config base directory
       ## XDG path
-      [ENV['XDG_CONFIG_HOME', Pathname.new(Dir.home).join('.config')]].each do |dir|
+      [ENV['XDG_CONFIG_HOME'],  Pathname.new(Dir.home).join('.config')].each do |dir|
         option_parser.config_files.class.supported_extensions.each do |ext|
           option_parser.config_files << Pathname.new(dir).join(WPScan.app_name, "scan.#{ext}").to_s
         end

--- a/lib/wpscan/controllers.rb
+++ b/lib/wpscan/controllers.rb
@@ -16,6 +16,14 @@ module WPScan
 
     # Registers the potential option-file paths with the option_parser.
     def register_config_files
+      # XDG support for config base directory
+      ## XDG path
+      [ENV['XDG_CONFIG_HOME', Pathname.new(Dir.home).join('.config')], ].each do |dir|
+        option_parser.config_files.class.supported_extensions.each do |ext|
+          option_parser.config_files << Pathname.new(dir).join("#{WPScan.app_name}", "scan.#{ext}").to_s
+        end
+      end
+      ## legacy path + working directory
       [Dir.home, Dir.pwd].each do |dir|
         option_parser.config_files.class.supported_extensions.each do |ext|
           option_parser.config_files << Pathname.new(dir).join(".#{WPScan.app_name}", "scan.#{ext}").to_s

--- a/spec/lib/controllers_spec.rb
+++ b/spec/lib/controllers_spec.rb
@@ -140,7 +140,6 @@ describe WPScan::Controllers do
     it 'register the correct files' do
       expect(File).to receive(:exist?).exactly(4).times.and_return(true)
 
-      expected = []
       option_parser = controllers.option_parser
 
       xdg = ENV.fetch('XDG_CONFIG_HOME', nil)
@@ -150,8 +149,8 @@ describe WPScan::Controllers do
       dirs = [[xdg, app], [Dir.home, ".#{app}"], [Dir.pwd, ".#{app}"]]
       exts = option_parser.config_files.class.supported_extensions
 
-      dirs.product(exts).each do |(dir, sub), ext|
-        expected << Pathname.new(dir).join(sub, "scan.#{ext}").to_s
+      expected = dirs.product(exts).map do |(dir, sub), ext|
+        Pathname.new(dir).join(sub, "scan.#{ext}").to_s
       end
 
       expect(option_parser.config_files.map(&:path)).to eql expected

--- a/spec/lib/controllers_spec.rb
+++ b/spec/lib/controllers_spec.rb
@@ -138,7 +138,7 @@ describe WPScan::Controllers do
 
   describe '#register_config_files' do
     it 'register the correct files' do
-      expect(File).to receive(:exist?).exactly(4).times.and_return(true)
+      expect(File).to receive(:exist?).exactly(6).times.and_return(true)
 
       option_parser = controllers.option_parser
 

--- a/spec/lib/controllers_spec.rb
+++ b/spec/lib/controllers_spec.rb
@@ -143,10 +143,15 @@ describe WPScan::Controllers do
       expected = []
       option_parser = controllers.option_parser
 
-      [Dir.home, Dir.pwd].each do |dir|
-        option_parser.config_files.class.supported_extensions.each do |ext|
-          expected << File.join(dir, '.wpscan', "scan.#{ext}")
-        end
+      xdg = ENV.fetch('XDG_CONFIG_HOME', nil)
+      xdg = Pathname.new(Dir.home).join('.config') if xdg.nil? || xdg.empty?
+      app = WPScan.app_name
+
+      dirs = [[xdg, app], [Dir.home, ".#{app}"], [Dir.pwd, ".#{app}"]]
+      exts = option_parser.config_files.class.supported_extensions
+
+      dirs.product(exts).each do |(dir, sub), ext|
+        expected << Pathname.new(dir).join(sub, "scan.#{ext}").to_s
       end
 
       expect(option_parser.config_files.map(&:path)).to eql expected


### PR DESCRIPTION
Related to https://github.com/wpscanteam/wpscan/issues/1586#issuecomment-4441989010

XDG Support asked in #1586 was partially supported in #1815 (only database in cache folder)

This PR also brings XDG Support for the config directory

## Proposed changes

Follows https://specifications.freedesktop.org/basedir/latest/ for config

## Why are these changes being made?

Complete #1815 for #1586 100% support

## Testing instructions

- Create $XDG_CONFIG_HOME env. var. to a custom location and create a scan.{json,yml} there
- Create ~/.config/wpscan/scan.{json,yml}

See if it is taken into account.

Also check previously supported path are still working.

If the PR is accepted, please complete https://github.com/wpscanteam/wpscan/blob/master/spec/lib/controllers_spec.rb#L139-L154

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor grants Automattic Inc. the unlimited, non-exclusive right to reuse, modify, and relicense the code.

