### PR TITLE
variabilise hardcoded value

### DIFF
--- a/lib/wpscan.rb
+++ b/lib/wpscan.rb
@@ -65,8 +65,8 @@ module WPScan
   # XDG support for DB_DIR
   # If the legacy path exists, it will be used. Otherwise, we'll use
   # $XDG_CACHE_HOME/wpscan/db or ~/.cache/wpscan/db when XDG_CACHE_HOME is unset.
-  legacy_path = Pathname.new(Dir.home).join('.wpscan', 'db')
-  xdg_path = Pathname.new(ENV['XDG_CACHE_HOME'] || Pathname.new(Dir.home).join('.cache')).join('wpscan', 'db')
+  legacy_path = Pathname.new(Dir.home).join(".#{WPScan.app_name}", 'db')
+  xdg_path = Pathname.new(ENV['XDG_CACHE_HOME'] || Pathname.new(Dir.home).join('.cache')).join(WPScan.app_name, 'db')
   DB_DIR = legacy_path.exist? ? legacy_path : xdg_path
 
   Typhoeus.on_complete do |response|

--- a/lib/wpscan.rb
+++ b/lib/wpscan.rb
@@ -54,6 +54,15 @@ require 'wpscan/http_status_tracking'
 Encoding.default_external = Encoding::UTF_8
 
 module WPScan
+  class << self
+    # The lowercase name of the scanner.
+    # Mainly used in directory paths like the default cookie-jar file and
+    # path to load the cli options from files.
+    def app_name
+      'wpscan'
+    end
+  end
+
   extend HttpStatusTracking
 
   APP_DIR = Pathname.new(__FILE__).dirname.join('..', 'app').expand_path
@@ -87,13 +96,6 @@ module WPScan
   end
 
   class << self
-    # The lowercase name of the scanner.
-    # Mainly used in directory paths like the default cookie-jar file and
-    # path to load the cli options from files.
-    def app_name
-      'wpscan'
-    end
-
     def user_cache_dir
       Pathname.new(ENV['XDG_CACHE_HOME'] || Pathname.new(Dir.home).join('.cache')).join(app_name)
     end


### PR DESCRIPTION
Related to https://github.com/wpscanteam/wpscan/pull/1815

## Proposed changes

Avoid hardcoding wpscan, use the same syntax as in https://github.com/wpscanteam/wpscan/blob/1845814cf716332b4a70cde9f167d3455fe1e0db/lib/wpscan/controllers.rb#L21

## Why are these changes being made?

Homogeneity, less hardcoded values

## Testing instructions

Run tests, nothing should change

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor grants Automattic Inc. the unlimited, non-exclusive right to reuse, modify, and relicense the code.

