### PR TITLE
Ports wpscanteam/CMSScanner#257 (make cli-no-color default for file output) and extends it with TTY and NO_COLOR checks.

### DIFF
--- a/lib/wpscan/controllers.rb
+++ b/lib/wpscan/controllers.rb
@@ -36,10 +36,24 @@ module WPScan
       self
     end
 
+    # Force the non-colored CLI formatter when ANSI escapes would be
+    # unwanted: writing to a file, piping to another process, or when the
+    # caller has set NO_COLOR (see https://no-color.org). Explicit
+    # --format choices are preserved.
+    def apply_no_colour_default
+      return if WPScan::ParsedCli.options[:format]
+
+      no_color = ENV.fetch('NO_COLOR', nil)
+      return unless WPScan::ParsedCli.output || !$stdout.tty? || (no_color && !no_color.empty?)
+
+      WPScan::ParsedCli.options[:format] = 'cli-no-colour'
+    end
+
     def run
       WPScan::ParsedCli.options = option_parser.results
       first.class.option_parser = option_parser # needed to output help on -h/--hh
 
+      apply_no_colour_default
       redirect_output_to_file(WPScan::ParsedCli.output) if WPScan::ParsedCli.output
 
       Timeout.timeout(WPScan::ParsedCli.max_scan_duration, WPScan::Error::MaxScanDurationReached) do

--- a/spec/lib/controllers_spec.rb
+++ b/spec/lib/controllers_spec.rb
@@ -136,6 +136,65 @@ describe WPScan::Controllers do
     end
   end
 
+  describe '#apply_no_colour_default' do
+    let(:no_color) { nil }
+
+    before do
+      ENV['NO_COLOR'] = no_color
+      allow($stdout).to receive(:tty?).and_return(tty)
+    end
+
+    after { ENV.delete('NO_COLOR') }
+
+    let(:tty) { true }
+
+    def options_after(opts)
+      WPScan::ParsedCli.options = opts
+      controllers.send(:apply_no_colour_default)
+      WPScan::ParsedCli.options
+    end
+
+    context 'when --output is set' do
+      it 'forces cli-no-colour' do
+        expect(options_after(output: '/tmp/out.txt')[:format]).to eql 'cli-no-colour'
+      end
+
+      it 'preserves an explicit --format' do
+        expect(options_after(output: '/tmp/out.txt', format: 'json')[:format]).to eql 'json'
+      end
+    end
+
+    context 'when stdout is not a TTY' do
+      let(:tty) { false }
+
+      it 'forces cli-no-colour' do
+        expect(options_after({})[:format]).to eql 'cli-no-colour'
+      end
+    end
+
+    context 'when NO_COLOR is set' do
+      let(:no_color) { '1' }
+
+      it 'forces cli-no-colour' do
+        expect(options_after({})[:format]).to eql 'cli-no-colour'
+      end
+    end
+
+    context 'when NO_COLOR is set but empty' do
+      let(:no_color) { '' }
+
+      it 'does not change the format' do
+        expect(options_after({})[:format]).to be_nil
+      end
+    end
+
+    context 'when stdout is a TTY, no --output and no NO_COLOR' do
+      it 'does not change the format' do
+        expect(options_after({})[:format]).to be_nil
+      end
+    end
+  end
+
   describe '#register_config_files' do
     it 'register the correct files' do
       expect(File).to receive(:exist?).exactly(4).times.and_return(true)


### PR DESCRIPTION
Resolves https://github.com/wpscanteam/CMSScanner/pull/257

  ## Proposed changes

  * Default `--format` to `cli-no-colour` when `--output FILE` is passed, so ANSI colour escapes don't end up inside the output file.
  * Also apply the same default when stdout is not a TTY (piped/redirected) or when the [`NO_COLOR`](https://no-color.org) environment variable is set to a non-empty value.
  * An explicit `--format` flag always wins: the new default only fills in when the user hasn't picked one.


  ## Why are these changes being made?

  <!--
  It's easy to see what a PR does but much harder to find out why it was made,
  particularly when researching old changes in history. Record an explanation of
  the motivation behind this change and how it will help.
  -->

  * Ports [wpscanteam/CMSScanner#257](https://github.com/wpscanteam/CMSScanner/pull/257) by @ngducdun, which was never applied here because WPScan has since absorbed the CMSScanner codebase. Without it, `wpscan
   -o report.txt` produces a file polluted with raw escape sequences like `^[[32m[+]^[[0m`, which is unreadable in editors that don't interpret ANSI.
  * Extending the same logic to non-TTY stdout and `NO_COLOR` covers the other common cases where colour codes are unwanted (CI logs, `wpscan ... | tee`, `wpscan ... > out.txt`, users who set `NO_COLOR` globally), without requiring callers to remember `-f cli-no-colour` every time.

  ## Testing instructions

  <!--
  Add as many details as possible to help others reproduce the issue and test the fix.
  "Before / After" screenshots can also be very helpful when the change is visual.
  -->

  * Output to a file and confirm no escape sequences are written:
    ```sh
    ruby -Ilib bin/wpscan --url https://example.com -o /tmp/wpscan.txt
    grep -c $'\e\[' /tmp/wpscan.txt   # expect 0
    ```
  * Pipe to a non-TTY and confirm the output is plain text:
    ```sh
    ruby -Ilib bin/wpscan --url https://example.com | cat
    ```
  * Set `NO_COLOR` and confirm colours are suppressed even on a TTY:
    ```sh
    NO_COLOR=1 ruby -Ilib bin/wpscan --url https://example.com | head
    ```
  * Verify that an explicit `--format` still wins (you should see colors):
    ```sh
    NO_COLOR=1  ruby -Ilib bin/wpscan --url https://example.com -o /tmp/out.json -f cli
    ```

