### PR TITLE
Added UID and GID to error output when something is not readable/writeable/executable, to help diagnose issues.

### DIFF
--- a/lib/opt_parse_validator/opts/path.rb
+++ b/lib/opt_parse_validator/opts/path.rb
@@ -52,12 +52,12 @@ module OptParseValidator
 
     # @param [ Pathname ] path
     def check_executable(path)
-      raise Error, "The path '#{path}' is not executable" unless path.executable?
+      raise Error, "The path '#{path}' is not executable#{process_identity}" unless path.executable?
     end
 
     # @param [ Pathname ] path
     def check_readable(path)
-      raise Error, "The path '#{path}' is not readable" unless path.readable?
+      raise Error, "The path '#{path}' is not readable#{process_identity}" unless path.readable?
     end
 
     # If the path does not exist, it will check for the parent
@@ -65,7 +65,14 @@ module OptParseValidator
     #
     # @param [ Pathname ] path
     def check_writable(path)
-      raise Error, "The path '#{path}' is not writable" if (path.exist? && !path.writable?) || !path.parent.writable?
+      return unless (path.exist? && !path.writable?) || !path.parent.writable?
+
+      raise Error, "The path '#{path}' is not writable#{process_identity}"
+    end
+
+    # @return [ String ] Current process uid/gid, formatted for inclusion in error messages
+    def process_identity
+      " (uid=#{Process.uid}, gid=#{Process.gid})"
     end
   end
 end

--- a/spec/lib/opt_parse_validator/opts/file_path_spec.rb
+++ b/spec/lib/opt_parse_validator/opts/file_path_spec.rb
@@ -80,7 +80,8 @@ describe OptParseValidator::OptFilePath do
       it 'raises an error if not ' do
         expect do
           opt.validate(file_path)
-        end.to raise_error(OptParseValidator::Error, "The path '#{file_path}' is not executable")
+        end.to raise_error(OptParseValidator::Error,
+                           "The path '#{file_path}' is not executable (uid=#{Process.uid}, gid=#{Process.gid})")
       end
     end
 
@@ -96,7 +97,8 @@ describe OptParseValidator::OptFilePath do
 
         expect do
           opt.validate(file_path)
-        end.to raise_error(OptParseValidator::Error, "The path '#{file_path}' is not readable")
+        end.to raise_error(OptParseValidator::Error,
+                           "The path '#{file_path}' is not readable (uid=#{Process.uid}, gid=#{Process.gid})")
       end
     end
 
@@ -113,7 +115,8 @@ describe OptParseValidator::OptFilePath do
 
           expect do
             opt.validate(file_path)
-          end.to raise_error(OptParseValidator::Error, "The path '#{file_path}' is not writable")
+          end.to raise_error(OptParseValidator::Error,
+                             "The path '#{file_path}' is not writable (uid=#{Process.uid}, gid=#{Process.gid})")
         end
       end
 
@@ -132,7 +135,10 @@ describe OptParseValidator::OptFilePath do
           let(:file) { OPV_FIXTURES.join('hfjhg', 'yolo.rb').to_s }
 
           it 'raises an error' do
-            expect { opt.validate(file) }.to raise_error(OptParseValidator::Error, "The path '#{file}' is not writable")
+            expect do
+              opt.validate(file)
+            end.to raise_error(OptParseValidator::Error,
+                               "The path '#{file}' is not writable (uid=#{Process.uid}, gid=#{Process.gid})")
           end
         end
       end


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Resolves https://github.com/wpscanteam/OptParseValidator/issues/99

## Proposed changes

* Add current UID & GID to output if things are not writable/readable/executable.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To help make it easier what might be the issue.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

CI has it pretty much covered, but if you really want to, you can do something like this manually and see the error:

```
wpscan --url <your-site> -o /tmp/non-existent-folder/blubb
```


