### PR TITLE
Remove unnecessary detection modes

### DIFF
--- a/app/controllers/enumeration/cli_options.rb
+++ b/app/controllers/enumeration/cli_options.rb
@@ -129,11 +129,6 @@ module WPScan
           OptFilePath.new(
             ['--db-exports-list FILE-PATH', 'List of DB exports\' paths to use'],
             exists: true, default: DB_DIR.join('db_exports.txt').to_s, advanced: true
-          ),
-          OptChoice.new(
-            ['--db-exports-detection MODE',
-             'Use the supplied mode to enumerate DB Exports, instead of the global (--detection-mode) mode.'],
-            choices: %w[mixed passive aggressive], normalize: :to_sym, advanced: true
           )
         ]
       end

--- a/app/controllers/enumeration/cli_options.rb
+++ b/app/controllers/enumeration/cli_options.rb
@@ -119,11 +119,6 @@ module WPScan
           OptFilePath.new(
             ['--config-backups-list FILE-PATH', 'List of config backups\' filenames to use'],
             exists: true, default: DB_DIR.join('config_backups.txt').to_s, advanced: true
-          ),
-          OptChoice.new(
-            ['--config-backups-detection MODE',
-             'Use the supplied mode to enumerate Config Backups, instead of the global (--detection-mode) mode.'],
-            choices: %w[mixed passive aggressive], normalize: :to_sym, advanced: true
           )
         ]
       end

--- a/app/controllers/enumeration/cli_options.rb
+++ b/app/controllers/enumeration/cli_options.rb
@@ -145,13 +145,7 @@ module WPScan
 
       # @return [ Array<OptParseValidator::OptBase> ]
       def cli_medias_opts
-        [
-          OptChoice.new(
-            ['--medias-detection MODE',
-             'Use the supplied mode to enumerate Medias, instead of the global (--detection-mode) mode.'],
-            choices: %w[mixed passive aggressive], normalize: :to_sym, advanced: true
-          )
-        ]
+        []
       end
 
       # @return [ Array<OptParseValidator::OptBase> ]

--- a/app/controllers/enumeration/cli_options.rb
+++ b/app/controllers/enumeration/cli_options.rb
@@ -109,11 +109,6 @@ module WPScan
           OptFilePath.new(
             ['--timthumbs-list FILE-PATH', 'List of timthumbs\' location to use'],
             exists: true, default: DB_DIR.join('timthumbs-v3.txt').to_s, advanced: true
-          ),
-          OptChoice.new(
-            ['--timthumbs-detection MODE',
-             'Use the supplied mode to enumerate Timthumbs, instead of the global (--detection-mode) mode.'],
-            choices: %w[mixed passive aggressive], normalize: :to_sym, advanced: true
           )
         ]
       end

--- a/app/controllers/enumeration/enum_methods.rb
+++ b/app/controllers/enumeration/enum_methods.rb
@@ -240,9 +240,9 @@ module WPScan
       end
 
       def enum_config_backups
-        opts = default_opts('config_backups').merge(list: ParsedCli.config_backups_list)
+        opts = { list: ParsedCli.config_backups_list, show_progression: user_interaction? }
 
-        output('@info', msg: "Enumerating Config Backups #{enum_detection_message(opts[:mode])}") if user_interaction?
+        output('@info', msg: 'Enumerating Config Backups') if user_interaction?
         output('config_backups', config_backups: target.config_backups(opts))
       end
 

--- a/app/controllers/enumeration/enum_methods.rb
+++ b/app/controllers/enumeration/enum_methods.rb
@@ -261,12 +261,11 @@ module WPScan
       end
 
       def enum_medias
-        opts = default_opts('medias').merge(range: ParsedCli.enumerate[:medias])
+        opts = { range: ParsedCli.enumerate[:medias], show_progression: user_interaction? }
 
         if user_interaction?
           output('@info',
-                 msg: "Enumerating Medias #{enum_detection_message(opts[:mode])} " \
-                      '(Permalink setting must be set to "Plain" for those to be detected)')
+                 msg: 'Enumerating Medias (Permalink setting must be set to "Plain" for those to be detected)')
         end
 
         output('medias', medias: target.medias(opts))

--- a/app/controllers/enumeration/enum_methods.rb
+++ b/app/controllers/enumeration/enum_methods.rb
@@ -233,9 +233,9 @@ module WPScan
       end
 
       def enum_timthumbs
-        opts = default_opts('timthumbs').merge(list: ParsedCli.timthumbs_list)
+        opts = { list: ParsedCli.timthumbs_list, show_progression: user_interaction? }
 
-        output('@info', msg: "Enumerating Timthumbs #{enum_detection_message(opts[:mode])}") if user_interaction?
+        output('@info', msg: 'Enumerating Timthumbs') if user_interaction?
         output('timthumbs', timthumbs: target.timthumbs(opts))
       end
 

--- a/app/controllers/enumeration/enum_methods.rb
+++ b/app/controllers/enumeration/enum_methods.rb
@@ -247,9 +247,9 @@ module WPScan
       end
 
       def enum_db_exports
-        opts = default_opts('db_exports').merge(list: ParsedCli.db_exports_list)
+        opts = { list: ParsedCli.db_exports_list, show_progression: user_interaction? }
 
-        output('@info', msg: "Enumerating DB Exports #{enum_detection_message(opts[:mode])}") if user_interaction?
+        output('@info', msg: 'Enumerating DB Exports') if user_interaction?
         output('db_exports', db_exports: target.db_exports(opts))
       end
 

--- a/spec/app/controllers/enumeration_spec.rb
+++ b/spec/app/controllers/enumeration_spec.rb
@@ -73,7 +73,7 @@ describe WPScan::Controller::Enumeration do
            plugins_list plugins_detection plugins_version_all plugins_version_detection plugins_threshold
            themes_list themes_detection themes_version_all themes_version_detection themes_threshold
            timthumbs_list
-           config_backups_list config_backups_detection
+           config_backups_list
            db_exports_list db_exports_detection
            backup_folders_list
            medias_detection

--- a/spec/app/controllers/enumeration_spec.rb
+++ b/spec/app/controllers/enumeration_spec.rb
@@ -74,7 +74,7 @@ describe WPScan::Controller::Enumeration do
            themes_list themes_detection themes_version_all themes_version_detection themes_threshold
            timthumbs_list
            config_backups_list
-           db_exports_list db_exports_detection
+           db_exports_list
            backup_folders_list
            medias_detection
            users_list users_detection exclude_usernames]

--- a/spec/app/controllers/enumeration_spec.rb
+++ b/spec/app/controllers/enumeration_spec.rb
@@ -76,7 +76,6 @@ describe WPScan::Controller::Enumeration do
            config_backups_list
            db_exports_list
            backup_folders_list
-           medias_detection
            users_list users_detection exclude_usernames]
       )
     end

--- a/spec/app/controllers/enumeration_spec.rb
+++ b/spec/app/controllers/enumeration_spec.rb
@@ -72,7 +72,7 @@ describe WPScan::Controller::Enumeration do
         %i[enumerate exclude_content_based
            plugins_list plugins_detection plugins_version_all plugins_version_detection plugins_threshold
            themes_list themes_detection themes_version_all themes_version_detection themes_threshold
-           timthumbs_list timthumbs_detection
+           timthumbs_list
            config_backups_list config_backups_detection
            db_exports_list db_exports_detection
            backup_folders_list


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Related to #2024

## Proposed changes

* Remove `--timthumbs-detection` CLI option
* Remove `--config-backups-detection` CLI option
* Remove `--db-exports-detection` CLI option
* Remove `--medias-detection` CLI option
* Update enumeration methods to always run these enumerations without mode detection

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Code cleanup.

These four enumeration types only implement aggressive detection (no passive finders exist). The detection-mode options were non-functional and misleading. When users specified passive mode, they got zero results, causing confusion.

This simplifies the CLI by removing 4 non-functional options and makes it explicit these scans are always aggressive (consistent with backup-folders enumeration which also has no detection-mode option, introduced in https://github.com/wpscanteam/wpscan/pull/2024).

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Verify that the removed CLI options are no longer available:

   ```bash
   wpscan --help
   # Should not show --timthumbs-detection, --config-backups-detection,
   # --db-exports-detection, or --medias-detection
   ```

2. Verify that enumeration still works for these types:

   ```bash
   wpscan --url http://example.com -e tt,cb,dbe,m
   ```

3. Verify that the enumeration output message no longer mentions detection mode:

   ```
   # Before: "Enumerating Timthumbs (via Passive and Aggressive Methods)"
   # After:  "Enumerating Timthumbs"
   ```

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor grants Automattic Inc. the unlimited, non-exclusive right to reuse, modify, and relicense the code.

