### PR TITLE
Use require_relative in gemspec

### DIFF
--- a/wpscan.gemspec
+++ b/wpscan.gemspec
@@ -1,7 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-
-require 'wpscan/version'
+require_relative 'lib/wpscan/version'
 
 Gem::Specification.new do |s|
   s.name                  = 'wpscan'


### PR DESCRIPTION
Resolves https://github.com/wpscanteam/CMSScanner/pull/207

## Proposed changes

* Replace manual `$LOAD_PATH` manipulation with `require_relative` in wpscan.gemspec

## Why are these changes being made?

CMSScanner was merged into wpscan, and @noraj proposed this on https://github.com/wpscanteam/CMSScanner/pull/207. The change modernizes the gemspec to use `require_relative` instead of manually manipulating `$LOAD_PATH`, which is more idiomatic and cleaner to read.

## Testing instructions

Trust the CI, or:
* `bundle install` - verify dependencies install correctly
* `bundle exec rake build` - verify gem builds successfully
* `ruby -Ilib bin/wpscan --help` - verify the tool runs 

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor grants Automattic Inc. the unlimited, non-exclusive right to reuse, modify, and relicense the code.