### PR TITLE
Standardize on Pathname objects for path handling

### DIFF
--- a/app/controllers/core/cli_options.rb
+++ b/app/controllers/core/cli_options.rb
@@ -122,7 +122,7 @@ module WPScan
                           writable: true,
                           readable: true,
                           create: true,
-                          default: File.join(tmp_directory, 'cookie_jar.txt')),
+                          default: tmp_directory.join('cookie_jar.txt')),
           OptBoolean.new(['--expect-saml',
                           'Expect SAML authentication to be required. ' \
                           'When the target redirects to a SAML IdP, an interactive browser ' \
@@ -142,7 +142,7 @@ module WPScan
                                readable: true,
                                writable: true,
                                create: true,
-                               default: File.join(tmp_directory, 'cache'),
+                               default: tmp_directory.join('cache'),
                                advanced: true)
         ]
       end

--- a/app/controllers/enumeration/cli_options.rb
+++ b/app/controllers/enumeration/cli_options.rb
@@ -108,7 +108,7 @@ module WPScan
         [
           OptFilePath.new(
             ['--timthumbs-list FILE-PATH', 'List of timthumbs\' location to use'],
-            exists: true, default: DB_DIR.join('timthumbs-v3.txt').to_s, advanced: true
+            exists: true, default: DB_DIR.join('timthumbs-v3.txt'), advanced: true
           )
         ]
       end
@@ -118,7 +118,7 @@ module WPScan
         [
           OptFilePath.new(
             ['--config-backups-list FILE-PATH', 'List of config backups\' filenames to use'],
-            exists: true, default: DB_DIR.join('config_backups.txt').to_s, advanced: true
+            exists: true, default: DB_DIR.join('config_backups.txt'), advanced: true
           )
         ]
       end
@@ -128,7 +128,7 @@ module WPScan
         [
           OptFilePath.new(
             ['--db-exports-list FILE-PATH', 'List of DB exports\' paths to use'],
-            exists: true, default: DB_DIR.join('db_exports.txt').to_s, advanced: true
+            exists: true, default: DB_DIR.join('db_exports.txt'), advanced: true
           )
         ]
       end
@@ -138,7 +138,7 @@ module WPScan
         [
           OptFilePath.new(
             ['--backup-folders-list FILE-PATH', 'List of backup folders to use'],
-            exists: true, default: DB_DIR.join('backup_folders.txt').to_s, advanced: true
+            exists: true, default: DB_DIR.join('backup_folders.txt'), advanced: true
           )
         ]
       end

--- a/lib/wpscan/controller.rb
+++ b/lib/wpscan/controller.rb
@@ -70,11 +70,11 @@ module WPScan
         formatter.user_interaction? && !WPScan::ParsedCli.output
       end
 
-      # @return [ String ]
+      # @return [ Pathname ]
       def tmp_directory
-        return Pathname.new(ENV['TMPDIR']).join(WPScan.app_name).to_s if ENV['TMPDIR']
+        return Pathname.new(ENV['TMPDIR']).join(WPScan.app_name) if ENV['TMPDIR']
 
-        WPScan.user_cache_dir.to_s
+        WPScan.user_cache_dir
       end
 
       protected

--- a/lib/wpscan/db/dynamic_finders/base.rb
+++ b/lib/wpscan/db/dynamic_finders/base.rb
@@ -4,9 +4,9 @@ module WPScan
   module DB
     module DynamicFinders
       class Base
-        # @return [ String ]
+        # @return [ Pathname ]
         def self.df_file
-          @df_file ||= DB_DIR.join('dynamic_finders.yml').to_s
+          @df_file ||= DB_DIR.join('dynamic_finders.yml')
         end
 
         # @return [ Hash ]

--- a/lib/wpscan/db/fingerprints.rb
+++ b/lib/wpscan/db/fingerprints.rb
@@ -33,9 +33,9 @@ module WPScan
         unique_fingerprints
       end
 
-      # @return [ String ]
+      # @return [ Pathname ]
       def self.wp_fingerprints_path
-        @wp_fingerprints_path ||= DB_DIR.join('wp_fingerprints.json').to_s
+        @wp_fingerprints_path ||= DB_DIR.join('wp_fingerprints.json')
       end
 
       # @return [ Hash ]

--- a/lib/wpscan/db/wp_item.rb
+++ b/lib/wpscan/db/wp_item.rb
@@ -16,9 +16,9 @@ module WPScan
         @metadata ||= read_json_file(metadata_file)
       end
 
-      # @return [ String ]
+      # @return [ Pathname ]
       def self.metadata_file
-        @metadata_file ||= DB_DIR.join('metadata.json').to_s
+        @metadata_file ||= DB_DIR.join('metadata.json')
       end
     end
   end

--- a/spec/app/finders/backup_folders/known_locations_spec.rb
+++ b/spec/app/finders/backup_folders/known_locations_spec.rb
@@ -4,7 +4,7 @@ describe WPScan::Finders::BackupFolders::KnownLocations do
   subject(:finder) { described_class.new(target) }
   let(:target)     { WPScan::Target.new(url) }
   let(:url)        { 'http://ex.lo/' }
-  let(:opts)       { { list: WPScan::DB_DIR.join('backup_folders.txt').to_s } }
+  let(:opts)       { { list: WPScan::DB_DIR.join('backup_folders.txt') } }
 
   describe '#aggressive' do
     before do

--- a/spec/app/finders/config_backups/known_filenames_spec.rb
+++ b/spec/app/finders/config_backups/known_filenames_spec.rb
@@ -5,7 +5,7 @@ describe WPScan::Finders::ConfigBackups::KnownFilenames do
   let(:target)     { WPScan::Target.new(url) }
   let(:url)        { 'http://ex.lo/' }
   let(:fixtures)   { FINDERS_FIXTURES.join('config_backups') }
-  let(:opts)       { { list: WPScan::DB_DIR.join('config_backups.txt').to_s } }
+  let(:opts)       { { list: WPScan::DB_DIR.join('config_backups.txt') } }
 
   describe '#aggressive' do
     before do

--- a/spec/app/finders/db_exports/known_locations_spec.rb
+++ b/spec/app/finders/db_exports/known_locations_spec.rb
@@ -5,7 +5,7 @@ describe WPScan::Finders::DbExports::KnownLocations do
   let(:target)     { WPScan::Target.new(url) }
   let(:url)        { 'http://ex.lo/aa/' }
   let(:fixtures)   { FINDERS_FIXTURES.join('db_exports') }
-  let(:opts)       { { list: WPScan::DB_DIR.join('db_exports.txt').to_s } }
+  let(:opts)       { { list: WPScan::DB_DIR.join('db_exports.txt') } }
 
   describe '#potential_urls' do
     before do

--- a/spec/lib/controller_spec.rb
+++ b/spec/lib/controller_spec.rb
@@ -29,7 +29,7 @@ describe WPScan::Controller do
         allow(Dir).to receive(:home).and_return('/home/user')
       end
 
-      its(:tmp_directory) { should eql '/home/user/.cache/wpscan' }
+      its(:tmp_directory) { should eql Pathname.new('/home/user/.cache/wpscan') }
     end
 
     context 'when TMPDIR is not set and XDG_CACHE_HOME is set' do
@@ -41,13 +41,13 @@ describe WPScan::Controller do
         stub_const('ENV', env)
       end
 
-      its(:tmp_directory) { should eql '/home/user/cache/wpscan' }
+      its(:tmp_directory) { should eql Pathname.new('/home/user/cache/wpscan') }
     end
 
     context 'when TMPDIR is set' do
       before { stub_const('ENV', ENV.to_hash.merge('TMPDIR' => '/home/user/tmp')) }
 
-      its(:tmp_directory) { should eql '/home/user/tmp/wpscan' }
+      its(:tmp_directory) { should eql Pathname.new('/home/user/tmp/wpscan') }
     end
   end
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Follow-up of https://github.com/wpscanteam/wpscan/pull/2034

## Proposed changes

* Remove `.to_s` from 4 enumeration CLI option defaults (timthumbs-list, config-backups-list, db-exports-list, backup-folders-list)
* Remove `.to_s` from 3 DB path getter methods (wp_fingerprints_path, metadata_file, df_file)
* Make `tmp_directory` method return `Pathname` instead of `String`
* Convert `File.join(tmp_directory, ...)` calls to `tmp_directory.join(...)` for cookie-jar and cache-dir defaults
* Update return type documentation from `String` to `Pathname` for affected methods
* Update test specs to match the new Pathname return types

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

#2034 changed `OptPath#validate` to return `Pathname` objects, but several places still explicitly converted paths to strings using `.to_s` (enumeration defaults, DB getters, tmp_directory method). This created a type mismatch where user-provided paths would be Pathname objects, but default values would be strings.

Removing these conversions completes the standardization, eliminates type inconsistency, and enables cleaner path manipulation using Pathname methods. All Ruby file operations accept Pathname objects, making these conversions unnecessary.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Trust the CI, and maybe verify output file creation works:

```bash
bundle exec ruby -Ilib bin/wpscan --help --output /tmp/test.txt
```

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor grants Automattic Inc. the unlimited, non-exclusive right to reuse, modify, and relicense the code.

