### PR TITLE
Avoid template injection for the release name.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,8 +19,10 @@ jobs:
 
       - name: Set tag to release name
         if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/')
+        env:
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          echo "DOCKER_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+          echo "DOCKER_TAG=$RELEASE_TAG_NAME" >> "$GITHUB_ENV"
 
       - name: Check if DOCKER_TAG is set
         if: env.DOCKER_TAG == ''


### PR DESCRIPTION
Addresses https://qlty.sh/gh/wpscanteam/projects/wpscan/issues/zizmor/zizmor/template-injection

zizmor's template-injection rule flags GitHub Actions expressions like `${{ github.event.release.tag_name }}` that are interpolated directly into a shell run: block. At runtime, GitHub substitutes the  expression before the shell sees it — so if the value contains shell metacharacters (backticks, $(...), ;, etc.), it gets executed as code with the runner's permissions. Release tag names are  attacker-influenceable (anyone who can cut a release).