### PR TITLE
Update WPScan banner

### DIFF
--- a/app/views/cli/core/banner.erb
+++ b/app/views/cli/core/banner.erb
@@ -6,9 +6,9 @@ _______________________________________________________________
             \  /\  /  | |     ____) | (__| (_| | | | |
              \/  \/   |_|    |_____/ \___|\__,_|_| |_|
 
-         WordPress Security Scanner by the WPScan Team
+                  WordPress Security Scanner
                          Version <%= WPScan::VERSION %>
-<%= ' ' * ((63 - WPScan::DB::Sponsor.text.length)/2) + WPScan::DB::Sponsor.text %>
-       @_WPScan_, @ethicalhack3r, @erwan_lr, @firefart
+                    An Automattic endeavor
+                    https://automattic.com
 _______________________________________________________________
 

--- a/app/views/json/core/banner.erb
+++ b/app/views/json/core/banner.erb
@@ -1,11 +1,5 @@
 "banner": {
-"description": "WordPress Security Scanner by the WPScan Team",
+"description": "WordPress Security Scanner",
   "version": <%= WPScan::VERSION.to_json %>,
-  "authors": [
-    "@_WPScan_",
-    "@ethicalhack3r",
-    "@erwan_lr",
-    "@firefart"
-  ],
-  "sponsor": <%= WPScan::DB::Sponsor.text.to_json %>
+  "sponsor": "An Automattic endeavor"
 },


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Related to #

## Proposed changes

* Updated CLI banner description from "WordPress Security Scanner by the WPScan Team" to "WordPress Security Scanner"
* Replaced individual author mentions with "An Automattic endeavor" and Automattic URL (https://automattic.com/)
* Simplified JSON banner output by removing authors array and replacing dynamic sponsor text with static "An Automattic endeavor" text
* Removed dependency on `WPScan::DB::Sponsor.text` in banner templates

<img width="1042" height="556" alt="CleanShot 2026-05-18 at 09 46 21@2x" src="https://github.com/user-attachments/assets/77ddd1df-112a-44d3-9988-08c9d250be5d" />

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Reflects Automattic's current ownership and maintenance of the WPScan project.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run WPScan with default output format and verify the banner displays correctly with the new branding

  ```bash
  ruby -Ilib bin/wpscan --url https://example.com
  ```

* Run WPScan with JSON output and verify the banner JSON structure is correct

  ```bash
  ruby -Ilib bin/wpscan --url https://example.com --format json
  ```

* Verify the banner text is properly centered and formatted in both CLI and JSON outputs

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor grants Automattic Inc. the unlimited, non-exclusive right to reuse, modify, and relicense the code.

