### PR TITLE
Implement skipped tests - round 2

### DIFF
--- a/lib/wpscan/scan.rb
+++ b/lib/wpscan/scan.rb
@@ -97,10 +97,9 @@ module WPScan
     # depending on the findings / errors
     # :nocov:
     def exit_hook
-      # Avoid hooking the exit when rspec is running, otherwise it will always return 0
-      # and Travis won't detect failed builds. Couldn't find a better way, even though
-      # some people managed to https://github.com/rspec/rspec-core/pull/410
-      return if defined?(RSpec)
+      # Avoid registering this hook when the RSpec suite is running, otherwise it
+      # can override RSpec's exit status and hide failed builds.
+      return if rspec_running?
 
       at_exit do
         exit(run_error_exit_code) if run_error
@@ -111,6 +110,10 @@ module WPScan
       end
     end
     # :nocov:
+
+    def rspec_running?
+      defined?(RSpec)
+    end
 
     # @return [ Integer ] The exit code related to the run_error
     def run_error_exit_code

--- a/spec/app/controllers/core_spec.rb
+++ b/spec/app/controllers/core_spec.rb
@@ -25,6 +25,12 @@ describe WPScan::Controller::Core do
   end
 
   describe '#load_server_module' do
+    before do
+      wp_item_class = WPScan::Model::WpItem
+
+      stub_const('WPScan::Model::WpItem', Class.new(wp_item_class))
+    end
+
     after do
       expect(core.target).to receive(:server).and_return(@stubbed_server)
       expect(core.load_server_module).to eql @expected

--- a/spec/app/models/wp_item_spec.rb
+++ b/spec/app/models/wp_item_spec.rb
@@ -165,11 +165,68 @@ describe WPScan::Model::WpItem do
   end
 
   describe '#directory_listing?' do
-    xit
+    let(:opts) { super().merge(url: item_url) }
+    let(:item_url) { "#{url}wp-content/plugins/test_item/" }
+
+    context 'when detection mode is :passive' do
+      let(:opts) { super().merge(mode: :passive) }
+
+      it 'returns false without making requests' do
+        expect(WPScan::Browser).not_to receive(:get)
+        expect(wp_item.directory_listing?).to be false
+      end
+    end
+
+    context 'when detection mode is not :passive' do
+      it 'returns true when the item URL has a directory listing' do
+        stub_request(:get, "#{item_url}assets/")
+          .to_return(status: 200, body: '<h1>Index of /assets/</h1>')
+
+        expect(wp_item.directory_listing?('assets/')).to be true
+      end
+
+      it 'returns false when the item URL does not have a directory listing' do
+        stub_request(:get, "#{item_url}assets/").to_return(status: 404)
+
+        expect(wp_item.directory_listing?('assets/')).to be false
+      end
+    end
   end
 
   describe '#error_log?' do
-    xit
+    let(:opts) { super().merge(url: item_url) }
+    let(:item_url) { "#{url}wp-content/plugins/test_item/" }
+
+    context 'when detection mode is :passive' do
+      let(:opts) { super().merge(mode: :passive) }
+
+      it 'returns false without checking for a log file' do
+        expect(wp_item).not_to receive(:log_file?)
+        expect(wp_item.error_log?).to be false
+      end
+    end
+
+    context 'when detection mode is not :passive' do
+      before { allow(blog).to receive(:head_or_get_params).and_return(method: :head) }
+
+      it 'returns true when the item error log matches the PHP error log pattern' do
+        stub_request(:head, "#{item_url}custom_error_log").to_return(status: 200)
+        stub_request(:get, "#{item_url}custom_error_log")
+          .with(headers: { 'Range' => 'bytes=0-700' })
+          .to_return(status: 200, body: 'PHP Fatal error: Uncaught Error')
+
+        expect(wp_item.error_log?('custom_error_log')).to be true
+      end
+
+      it 'returns false when the item error log does not match the PHP error log pattern' do
+        stub_request(:head, "#{item_url}custom_error_log").to_return(status: 200)
+        stub_request(:get, "#{item_url}custom_error_log")
+          .with(headers: { 'Range' => 'bytes=0-700' })
+          .to_return(status: 200, body: 'plain text')
+
+        expect(wp_item.error_log?('custom_error_log')).to be false
+      end
+    end
   end
 
   describe '#head_and_get' do

--- a/spec/dummy_independent_finders.rb
+++ b/spec/dummy_independent_finders.rb
@@ -23,6 +23,16 @@ module WPScan
           DummyFinding.new('spotted', confidence: 10, found_by: found_by)
         end
       end
+
+      # Finder returning more than one result
+      class MultipleResults < Finder
+        def passive(_opts = {})
+          [
+            DummyFinding.new('first', found_by: found_by),
+            DummyFinding.new('second', found_by: found_by)
+          ]
+        end
+      end
     end
   end
 end

--- a/spec/lib/finders/independent_finders_spec.rb
+++ b/spec/lib/finders/independent_finders_spec.rb
@@ -16,11 +16,14 @@ describe WPScan::Finders::IndependentFinders do
         finding.new('spotted', found_by: 'No Aggressive Result (Passive Detection)', confidence: 10)
       ]
     end
+    let(:extra_finders) { [] }
 
     before do
       finders <<
         WPScan::Finders::Independent::DummyFinder.new(target) <<
         WPScan::Finders::Independent::NoAggressiveResult.new(target)
+
+      extra_finders.each { |finder| finders << finder }
     end
 
     describe 'method calls order' do
@@ -92,7 +95,19 @@ describe WPScan::Finders::IndependentFinders do
       end
 
       context 'when multiple results returned' do
-        xit
+        let(:mode) { :passive }
+        let(:extra_finders) { [WPScan::Finders::Independent::MultipleResults.new(target)] }
+
+        it 'returns all results' do
+          expect(@found).to match_array(
+            (
+              expected_passive + [
+                finding.new('first', found_by: 'Multiple Results (Passive Detection)'),
+                finding.new('second', found_by: 'Multiple Results (Passive Detection)')
+              ]
+            ).map { |f| eql(f) }
+          )
+        end
       end
     end
   end

--- a/spec/lib/scan_spec.rb
+++ b/spec/lib/scan_spec.rb
@@ -121,8 +121,15 @@ describe WPScan::Scan do
   end
 
   describe '#exit_hook' do
-    # Cannot test: method explicitly returns early when RSpec is defined to avoid interfering
-    # with RSpec's exit code handling. See method comment referencing rspec/rspec-core#410
-    xit 'sets up at_exit hook for exit codes'
+    it 'sets up at_exit hook for exit codes' do
+      registered_hook = nil
+
+      allow(scanner).to receive(:rspec_running?).and_return(false)
+      expect(scanner).to receive(:at_exit) { |&block| registered_hook = block }
+
+      scanner.exit_hook
+
+      expect(registered_hook).to be_a(Proc)
+    end
   end
 end


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Related to https://github.com/wpscanteam/wpscan/pull/2037

## Proposed changes

* Implement the previously skipped `WPScan::Scan#exit_hook` spec by stubbing the RSpec runtime guard and asserting that an exit hook is registered.
* Implement the previously skipped `WPScan::Model::WpItem#directory_listing?` and `#error_log?` specs with HTTP stubs that cover passive mode, positive detection, and negative detection.
* Isolate the server module loading specs so they do not mutate `WPScan::Model::WpItem` for later examples.
* Implement the previously skipped `WPScan::Finders::IndependentFinders` multiple-results spec with a dummy finder that returns more than one finding.

This PR reduces the list from 10 to 6 skipped tests.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Reduce the number of skipped tests by turning testable pending examples into real coverage.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Trust the CI

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor grants Automattic Inc. the unlimited, non-exclusive right to reuse, modify, and relicense the code.

