### PR TITLE
Fix vuln_api_spec to properly isolate WPSCAN_API_TOKEN environment variable

### DIFF
--- a/spec/app/controllers/vuln_api_spec.rb
+++ b/spec/app/controllers/vuln_api_spec.rb
@@ -5,6 +5,15 @@ describe WPScan::Controller::VulnApi do
   let(:target_url)     { 'http://ex.lo/' }
   let(:cli_args)       { "--url #{target_url}" }
 
+  around do |example|
+    original_api_token = ENV.fetch(described_class::ENV_KEY, nil)
+
+    ENV.delete(described_class::ENV_KEY)
+    example.run
+  ensure
+    original_api_token ? ENV[described_class::ENV_KEY] = original_api_token : ENV.delete(described_class::ENV_KEY)
+  end
+
   before do
     WPScan::ParsedCli.options = rspec_parsed_options(cli_args)
     WPScan::DB::VulnApi.instance_variable_set(:@default_request_params, nil)


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

## Proposed changes

* Add an `around` hook in `vuln_api_spec.rb` to properly isolate the `WPSCAN_API_TOKEN` environment variable during test execution

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The test `WPScan::Controller::VulnApi#before_scan when no --api-token provided` was failing when the `WPSCAN_API_TOKEN` environment variable was set in the developer's shell. The test expected no API token to be present, but the controller checks both CLI args and the environment variable.

By using an `around` hook, we ensure the environment variable is temporarily cleared during test execution and properly restored afterward, preventing test pollution from the developer's environment configuration.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Set the `WPSCAN_API_TOKEN` environment variable in your shell:

   ```bash
   export WPSCAN_API_TOKEN="some-token"
   ```

2. Run the vuln_api_spec tests:

   ```bash
   bundle exec rspec spec/app/controllers/vuln_api_spec.rb
   ```

3. Verify all tests pass (10 examples, 0 failures)

4. Also verify it works without the environment variable:

   ```bash
   unset WPSCAN_API_TOKEN
   bundle exec rspec spec/app/controllers/vuln_api_spec.rb
   ```


## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor grants Automattic Inc. the unlimited, non-exclusive right to reuse, modify, and relicense the code.

