### PR TITLE
Changed docker release workflow so that we also always push the "latest" tag along with the versioned tag for the new version.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,19 +15,24 @@ jobs:
       - name: Set tag to latest
         if: (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'schedule'
         run: |
-          echo "DOCKER_TAG=latest" >> $GITHUB_ENV
+          echo "DOCKER_TAGS=wpscanteam/wpscan:latest" >> "$GITHUB_ENV"
 
-      - name: Set tag to release name
+      - name: Set tags to release name and latest
         if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/')
         env:
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          echo "DOCKER_TAG=$RELEASE_TAG_NAME" >> "$GITHUB_ENV"
+          {
+            echo "DOCKER_TAGS<<EOF"
+            echo "wpscanteam/wpscan:$RELEASE_TAG_NAME"
+            echo "wpscanteam/wpscan:latest"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
 
-      - name: Check if DOCKER_TAG is set
-        if: env.DOCKER_TAG == ''
+      - name: Check if DOCKER_TAGS is set
+        if: env.DOCKER_TAGS == ''
         run: |
-          echo DOCKER_TAG is not set!
+          echo DOCKER_TAGS is not set!
           exit 1
 
       - name: Set up QEMU
@@ -50,4 +55,4 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
-          tags: wpscanteam/wpscan:${{ env.DOCKER_TAG }}
+          tags: ${{ env.DOCKER_TAGS }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,22 +12,23 @@ jobs:
       - name: checkout sources
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
+      - name: Check release tag is set
+        if: github.event.release.tag_name == ''
+        run: |
+          echo "release tag_name is empty!"
+          exit 1
+
       - name: Set tags to release name and latest
         env:
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
+          DELIMITER="EOF_$(openssl rand -hex 16)"
           {
-            echo "DOCKER_TAGS<<EOF"
+            echo "DOCKER_TAGS<<$DELIMITER"
             echo "wpscanteam/wpscan:$RELEASE_TAG_NAME"
             echo "wpscanteam/wpscan:latest"
-            echo "EOF"
+            echo "$DELIMITER"
           } >> "$GITHUB_ENV"
-
-      - name: Check if DOCKER_TAGS is set
-        if: env.DOCKER_TAGS == ''
-        run: |
-          echo DOCKER_TAGS is not set!
-          exit 1
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,13 +12,7 @@ jobs:
       - name: checkout sources
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - name: Set tag to latest
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'schedule'
-        run: |
-          echo "DOCKER_TAGS=wpscanteam/wpscan:latest" >> "$GITHUB_ENV"
-
       - name: Set tags to release name and latest
-        if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/')
         env:
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,12 +21,17 @@ jobs:
       - name: Set tags to release name and latest
         env:
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          IS_PRERELEASE: ${{ github.event.release.prerelease }}
         run: |
           DELIMITER="EOF_$(openssl rand -hex 16)"
           {
             echo "DOCKER_TAGS<<$DELIMITER"
             echo "wpscanteam/wpscan:$RELEASE_TAG_NAME"
-            echo "wpscanteam/wpscan:latest"
+            # Only move the "latest" tag for stable releases, so it stays on the
+            # most recent real release and is never pointed at a prerelease.
+            if [ "$IS_PRERELEASE" != "true" ]; then
+              echo "wpscanteam/wpscan:latest"
+            fi
             echo "$DELIMITER"
           } >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Proposed changes

  * Update the Docker release workflow so a published release pushes both the versioned tag (e.g. `4.0.0`) and the `latest` tag in the same build.
  * Replace the single `DOCKER_TAG` env var with a multi-line `DOCKER_TAGS` var holding the full `wpscanteam/wpscan:<tag>` references, using a heredoc for the release case.
  * Update the guard step and `docker/build-push-action` `tags` input to consume the new `DOCKER_TAGS` variable.

  ## Why are these changes being made?

  * Previously a release only published the versioned tag, leaving `latest` stale until we fixed that manually.
  * Tagging both in a single multi-arch build keeps `latest` in sync with the released version and avoids a second build.

  ## Testing instructions

I guess we'll test it live with the next release? 🙂 

