### PR TITLE
Fix rubocop safe navigation empty check

### DIFF
--- a/app/finders/wp_items/urls_in_page.rb
+++ b/app/finders/wp_items/urls_in_page.rb
@@ -21,7 +21,7 @@ module WPScan
 
             slug = Regexp.last_match[1]&.strip
 
-            found << slug unless slug&.empty?
+            found << slug unless slug && slug.empty?
           end
 
           uniq ? found.uniq.sort : found.sort


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword.
-->

Related to #

## Proposed changes

* Update the slug emptiness check in `UrlsInPage` to satisfy RuboCop 1.88.0

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* #2060 is failing CI because RuboCop 1.88.0 reports `Lint/SafeNavigationWithEmpty` for `slug&.empty?` in `app/finders/wp_items/urls_in_page.rb`.
* The current failure is unrelated to the `actions/checkout` update and can be fixed independently with a one-line lint change.

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Trust the CI

## Licensing

By submitting code contributions to the WPScan development team via Github Pull Requests, or any other method, it is understood that the contributor grants Automattic Inc. the unlimited, non-exclusive right to reuse, modify, and relicense the code.

