### PR TITLE
Add 7-day Dependabot cooldown and limit Actions to major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,22 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # Wait 7 days after a release before opening an update PR
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+    # Wait 7 days after a release before opening an update PR
+    cooldown:
+      default-days: 7
+    # Only open PRs for new major versions to cut the noise from the
+    # frequent minor/patch bumps
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"


### PR DESCRIPTION
## Proposed changes

Two changes to `.github/dependabot.yml`:

1. **Default 7-day cooldown on all ecosystems** (`bundler` and `github-actions`) via [`cooldown.default-days`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown-). Dependabot now waits 7 days after a release before opening an update PR.

2. **GitHub Actions updates limited to new major versions** via an [`ignore`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore--) rule that skips `version-update:semver-minor` and `version-update:semver-patch` for all Action dependencies.

## Why

- **7-day cooldown → supply chain protection.** Compromised/malicious package releases are typically detected and yanked within a few days. Letting a new version "cool down" for a week before we pull it in significantly reduces our exposure to supply chain attacks, at the cost of only a short delay on legitimate updates.
- **Actions major-only → less noise.** Minor/patch bumps for GitHub Actions (e.g. `docker/login-action` `4.3.0 → 4.4.0`) arrive constantly and don't change functionality in a way that's relevant to us. Only surfacing new major versions keeps the important, potentially-breaking updates visible while eliminating the steady stream of low-value PRs.

## Testing instructions

Not much to test really, we'll have to see that dependabot behaves the way we like it to once this is merged.