### PR TITLE
Fix SimpleCov 1.0 deprecation warnings

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -11,9 +11,9 @@ if ENV['GITHUB_ACTION']
   SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
 end
 
-SimpleCov.start do
+SimpleCov.configure do
   enable_coverage :branch # Only supported for Ruby >= 2.5
 
-  add_filter '/spec/'
-  add_filter 'helper'
+  skip '/spec/'
+  skip 'helper'
 end

--- a/lib/opt_parse_validator/config_files_loader_merger.rb
+++ b/lib/opt_parse_validator/config_files_loader_merger.rb
@@ -4,7 +4,7 @@ require_relative 'config_files_loader_merger/base'
 require_relative 'config_files_loader_merger/json'
 require_relative 'config_files_loader_merger/yml'
 
-# :nocov:
+# simplecov:disable
 # @param [ String ] path The path of the file to load
 def yaml_safe_load(path)
   if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0.pre1') # Ruby 2.6
@@ -13,7 +13,7 @@ def yaml_safe_load(path)
     YAML.safe_load_file(path, [Regexp]) || {}
   end
 end
-# :nocov:
+# simplecov:enable
 
 module OptParseValidator
   # Options Files container

--- a/lib/wpscan/db/updater.rb
+++ b/lib/wpscan/db/updater.rb
@@ -3,7 +3,7 @@
 module WPScan
   module DB
     # Class used to perform DB updates
-    # :nocov:
+    # simplecov:disable
     class Updater
       # /!\ Might want to also update the Enumeration#cli_options when some filenames are changed here
       FILES = %w[
@@ -213,5 +213,5 @@ module WPScan
       end
     end
   end
-  # :nocov:
+  # simplecov:enable
 end

--- a/lib/wpscan/errors/http.rb
+++ b/lib/wpscan/errors/http.rb
@@ -61,20 +61,20 @@ module WPScan
 
     # HTTP Authentication Required Error
     class HTTPAuthRequired < Standard
-      # :nocov:
+      # simplecov:disable
       def to_s
         'HTTP authentication required (or was invalid), please provide it with --http-auth'
       end
-      # :nocov:
+      # simplecov:enable
     end
 
     # Proxy Authentication Required Error
     class ProxyAuthRequired < Standard
-      # :nocov:
+      # simplecov:disable
       def to_s
         'Proxy authentication required (or was invalid), please provide it with --proxy-auth'
       end
-      # :nocov:
+      # simplecov:enable
     end
 
     # Access Forbidden Error

--- a/lib/wpscan/errors/scan.rb
+++ b/lib/wpscan/errors/scan.rb
@@ -4,11 +4,11 @@ module WPScan
   module Error
     # Used instead of the Timeout::Error
     class MaxScanDurationReached < Standard
-      # :nocov:
+      # simplecov:disable
       def to_s
         'Max Scan Duration Reached'
       end
-      # :nocov:
+      # simplecov:enable
     end
   end
 end

--- a/lib/wpscan/scan.rb
+++ b/lib/wpscan/scan.rb
@@ -96,7 +96,7 @@ module WPScan
 
     # Hook to be able to have an exit code returned
     # depending on the findings / errors
-    # :nocov:
+    # simplecov:disable
     def exit_hook
       # Avoid registering this hook when the RSpec suite is running, otherwise it
       # can override RSpec's exit status and hide failed builds.
@@ -110,7 +110,7 @@ module WPScan
         exit(WPScan::ExitCode::OK)
       end
     end
-    # :nocov:
+    # simplecov:enable
 
     def rspec_running?
       defined?(RSpec)

--- a/lib/wpscan/web_site.rb
+++ b/lib/wpscan/web_site.rb
@@ -45,11 +45,11 @@ module WPScan
     # @return [ Typhoeus::Response ]
     #
     # As webmock does not support redirects mocking, coverage is ignored
-    # :nocov:
+    # simplecov:disable
     def homepage_res
       @homepage_res ||= WPScan::Browser.get_and_follow_location(url)
     end
-    # :nocov:
+    # simplecov:enable
 
     # @return [ String ]
     def homepage_url
@@ -108,7 +108,7 @@ module WPScan
     # @return [ String ] The redirection url or nil
     #
     # As webmock does not support redirects mocking, coverage is ignored
-    # :nocov:
+    # simplecov:disable
     def redirection(url = nil)
       url ||= @uri.to_s
 
@@ -118,7 +118,7 @@ module WPScan
 
       res.effective_url == url ? nil : res.effective_url
     end
-    # :nocov:
+    # simplecov:enable
 
     # @return [ Hash ] The Typhoeus params to use to perform head requests
     def head_or_get_params

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,8 @@
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
-require 'simplecov' # More config is defined in ./.simplecov
+require 'simplecov' # Configuration is defined in ./.simplecov
+SimpleCov.start
 require 'rspec/its'
 require 'webmock/rspec'
 require 'tmpdir'


### PR DESCRIPTION
Related to #2075

## Proposed changes

* Make `.simplecov` configuration-only (`SimpleCov.configure`) and move the `SimpleCov.start` call into `spec/spec_helper.rb`
* Replace the deprecated `add_filter` with `skip` in `.simplecov`
* Replace all `# :nocov:` markers with `# simplecov:disable` / `# simplecov:enable` block comments

## Why are these changes being made?

* The simplecov 1.0 upgrade (#2075) made every rspec run emit `[DEPRECATION]` warnings for calling `SimpleCov.start` from `.simplecov`, for `add_filter`, and for the `# :nocov:` syntax; all three are slated for removal in a future simplecov release

## Testing instructions

* Run `bundle exec rspec --tag ~slow` (or any single spec file) and confirm no `[DEPRECATION]` warnings appear in the output
* Confirm the coverage report still excludes `spec/` and helper files and still reports branch coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)