### PR TITLE
Run one non-slow example per dynamic finder code path

### DIFF
--- a/spec/lib/finders/dynamic_finder/plugin_version_spec.rb
+++ b/spec/lib/finders/dynamic_finder/plugin_version_spec.rb
@@ -16,15 +16,25 @@
 
 expected_all = df_expected_all['plugins']
 
+# Almost all of these generated specs are tagged as slow (there are tens of thousands of
+# them) and only run in the full suite on master. To keep the coverage reporting of PRs
+# (which run with --tag ~slow) stable, the first finder of each combination of
+# super class / path / version_key is not tagged, so that every underlying finder code
+# path is executed at least once on PRs. See https://github.com/wpscanteam/wpscan/pull/2070
+not_tagged_as_slow = Set.new
+
 WPScan::DB::DynamicFinders::Plugin.versions_finders_configs.each do |slug, configs|
   WPScan::DB::DynamicFinders::Plugin.create_versions_finders(slug)
 
   configs.each do |finder_class, config|
     finder_super_class = config['class'] || finder_class
 
+    combo    = [finder_super_class, config.key?('path'), config.key?('version_key')]
+    metadata = not_tagged_as_slow.add?(combo) ? {} : { slow: true }
+
     # The QueryParameter specs are slow given the huge fixture file
     # If someone find a fix for that, please share!
-    describe df_tested_class_constant('PluginVersion', finder_class, slug), slow: true do
+    describe df_tested_class_constant('PluginVersion', finder_class, slug), metadata do
       subject(:finder) { described_class.new(plugin) }
       let(:plugin)     { WPScan::Model::Plugin.new(slug, target) }
       let(:target)     { WPScan::Target.new('http://wp.lab/') }
@@ -40,7 +50,7 @@ WPScan::DB::DynamicFinders::Plugin.versions_finders_configs.each do |slug, confi
 
       before { allow(target).to receive(:content_dir).and_return('wp-content') }
 
-      describe '#passive', slow: true do
+      describe '#passive' do
         before do
           if defined?(stubbed_homepage_res)
             stub_request(:get, target.url).to_return(stubbed_homepage_res)

--- a/spec/lib/finders/dynamic_finder/theme_version_spec.rb
+++ b/spec/lib/finders/dynamic_finder/theme_version_spec.rb
@@ -16,15 +16,25 @@
 
 expected_all = df_expected_all['themes']
 
+# Almost all of these generated specs are tagged as slow and only run in the full suite
+# on master. To keep the coverage reporting of PRs (which run with --tag ~slow) stable,
+# the first finder of each combination of super class / path / version_key is not tagged,
+# so that every underlying finder code path is executed at least once on PRs.
+# See https://github.com/wpscanteam/wpscan/pull/2070
+not_tagged_as_slow = Set.new
+
 WPScan::DB::DynamicFinders::Theme.versions_finders_configs.each do |slug, configs|
   WPScan::DB::DynamicFinders::Theme.create_versions_finders(slug)
 
   configs.each do |finder_class, config|
     finder_super_class = config['class'] || finder_class
 
+    combo    = [finder_super_class, config.key?('path'), config.key?('version_key')]
+    metadata = not_tagged_as_slow.add?(combo) ? {} : { slow: true }
+
     # The QueryParameter specs are slow given the huge fixture file
     # If someone find a fix for that, please share!
-    describe df_tested_class_constant('ThemeVersion', finder_class, slug), slow: true do
+    describe df_tested_class_constant('ThemeVersion', finder_class, slug), metadata do
       subject(:finder) { described_class.new(theme) }
       let(:theme)      { WPScan::Model::Theme.new(slug, target) }
       let(:target)     { WPScan::Target.new('http://wp.lab/') }
@@ -45,7 +55,7 @@ WPScan::DB::DynamicFinders::Theme.versions_finders_configs.each do |slug, config
         stub_request(:get, target.url("wp-content/themes/#{slug}/style.css"))
       end
 
-      describe '#passive', slow: true do
+      describe '#passive' do
         before do
           if defined?(stubbed_homepage_res)
             stub_request(:get, target.url).to_return(stubbed_homepage_res)


### PR DESCRIPTION
## Proposed changes

The generated `PluginVersion` / `ThemeVersion` dynamic-finder specs iterate over **every** plugin/theme slug in the fixture DB, producing ~35,000 examples that are all tagged `slow`. Slow examples only run in the full suite on `master`; PR checks run with `--tag ~slow`.

As a result, none of the underlying finder code paths were being exercised on PRs, even though thousands of slow examples cover them on master. This is what makes coveralls report a small coverage drop on essentially every PR (e.g. #2070) — it's an artifact of the split test runs, not a real regression.

This PR un-tags the **first finder of each combination** of super class / `path` / `version_key`, so exactly one representative of each finder code path runs on PRs, while the remaining tens of thousands stay `slow` (master only):

```ruby
combo    = [finder_super_class, config.key?('path'), config.key?('version_key')]
metadata = not_tagged_as_slow.add?(combo) ? {} : { slow: true }
describe df_tested_class_constant('PluginVersion', finder_class, slug), metadata do
```

That's **11 representative examples** (10 plugin combos + 1 theme) instead of ~35k.

## Why

- Keeps PR coverage reporting stable so coveralls stops flagging a phantom drop on every PR.
- No literal duplication of the ~150 lines of shared test logic: any newly-added finder type automatically gets a representative.
- Turns out the previously-slow specs weren't reliably covering the `ConfigParser` / `JavascriptVar` (`version_key`) `find` paths even on master, so this also closes a genuine coverage gap.

## Impact (measured with `--tag ~slow`)

- **+19 lines / +15 branches** now covered by the non-slow suite, all in the dynamic-finder code (`config_parser.rb`, `body_pattern.rb`, `javascript_var.rb`, the 404 fallback in `finder.rb`, and the `wp_item_version.rb` overrides).
- Non-slow line coverage: **94.70% → 95.08%**.
- Negligible runtime: the 2 MB QueryParameter fixture is now loaded once instead of thousands of times; the 11 examples run in well under a second.
- The full slow suite on master is unchanged.

## Testing instructions

```bash
bundle exec rspec --tag ~slow spec/lib/finders/dynamic_finder/plugin_version_spec.rb \
                               spec/lib/finders/dynamic_finder/theme_version_spec.rb
```

Confirms the 11 representative examples run (and pass) without the `slow` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)